### PR TITLE
feat: lockdown genesis, deployment plugin, kotlin and auth version PTC-445:

### DIFF
--- a/.genx/prompts/index.js
+++ b/.genx/prompts/index.js
@@ -32,7 +32,7 @@ module.exports = async (inquirer, prevAns = {}) => {
   const {baseDsPackage, dsName} = await dsPrompts(inquirer, prevAns);
   almostThere();
   const {apiHost} = await apiPrompts(inquirer, prevAns)
-  const {genesisVersion, deployPluginVersion, kotlinVersion, groupId, applicationVersion} = await genesisServerPrompts(inquirer, prevAns);
+  const {groupId, applicationVersion} = await genesisServerPrompts(inquirer, prevAns);
 
   return {
     apiHost,
@@ -40,9 +40,6 @@ module.exports = async (inquirer, prevAns = {}) => {
     dsName,
     pkgScope,
     pkgName,
-    genesisVersion,
-    deployPluginVersion,
-    kotlinVersion,
     groupId,
     applicationVersion,
     workspaceName,

--- a/.genx/prompts/server.js
+++ b/.genx/prompts/server.js
@@ -1,43 +1,15 @@
 const {mavenArtifactVersionRegex} = require('./validators');
 
 module.exports = async (inquirer, prevAns = {}) => {
-    () => console.log(`Enter Genesis Server version`);
     const {
-      genesisVersion = prevAns.genesisVersion,
-      deployPluginVersion = prevAns.deployPluginVersion,
-      kotlinVersion = prevAns.kotlinVersion,
       groupId = prevAns.groupId,
       applicationVersion = prevAns.applicationVersion
     } = await inquirer.prompt([
       {
-        name: 'genesisVersion',
-        type: 'input',
-        message: 'Genesis Server version',
-        when: !prevAns.pkgScope,
-        default: '6.1.2',
-        validate: mavenArtifactVersionRegex,
-      },
-      {
-        name: 'deployPluginVersion',
-        type: 'input',
-        message: 'Genesis Deploy plugin version',
-        when: !prevAns.genesisVersion,
-        default:'6.1.2',
-        validate: mavenArtifactVersionRegex,
-      },
-      {
-        name: 'kotlinVersion',
-        type: 'input',
-        message: 'Kotlin version',
-        when: !prevAns.deployPluginVersion,
-        default:'1.6.10',
-        validate: mavenArtifactVersionRegex,
-      },
-      {
         name: 'groupId',
         type: 'input',
         message: 'Group Id',
-        when: !prevAns.kotlinVersion,
+        when: !prevAns.pkgScope,
         default:'global.genesis'
       },
       {
@@ -50,9 +22,6 @@ module.exports = async (inquirer, prevAns = {}) => {
       },
     ]);
     return {
-      genesisVersion,
-      deployPluginVersion,
-      kotlinVersion,
       groupId,
       applicationVersion
     };

--- a/server/jvm/build.gradle.kts
+++ b/server/jvm/build.gradle.kts
@@ -1,9 +1,9 @@
 ext.set("localDaogenVersion", "{{localGenId}}")
 
 plugins {
-    kotlin("jvm") version "{{kotlinVersion}}"
+    kotlin("jvm") version "1.6.10"
     `maven-publish`
-    id("global.genesis.build") version "{{genesisVersion}}"
+    id("global.genesis.build") version "6.1.7"
 }
 
 subprojects  {
@@ -12,9 +12,9 @@ subprojects  {
 
 
     dependencies {
-        implementation(platform("global.genesis:genesis-bom:{{genesisVersion}}"))
+        implementation(platform("global.genesis:genesis-bom:6.1.7"))
         implementation("org.agrona:agrona:1.10.0!!")
-        testImplementation("org.jetbrains.kotlin:kotlin-test-junit:{{kotlinVersion}}")
+        testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.6.10")
         constraints {
             // define versions of your dependencies here so that submodules do not have to define explcit versions
             testImplementation("junit:junit:4.13.2")

--- a/server/jvm/genesis-deploy/build.gradle.kts
+++ b/server/jvm/genesis-deploy/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("global.genesis.deploy") version "{{deployPluginVersion}}"
+    id("global.genesis.deploy") version "6.1.7"
 }
 
 description = "{{appName}}-deploy"
@@ -8,14 +8,14 @@ dependencies {
     implementation(
         group = "global.genesis",
         name = "genesis-distribution",
-        version = "{{genesisVersion}}",
+        version = "6.1.7",
         classifier = "bin",
         ext = "zip"
     )
     implementation(
         group = "global.genesis",
         name = "auth-distribution",
-        version = "{{genesisVersion}}",
+        version = "6.1.5",
         classifier = "bin",
         ext = "zip"
     )


### PR DESCRIPTION
[Review Guidance](https://genesisglobal.atlassian.net/wiki/spaces/ON/pages/2682257431/Platform+Code+Review+Process)

📓 &nbsp; **Related JIRA**



[PTC-445](https://genesisglobal.atlassian.net/browse/PTC-445)



🤔 &nbsp; **What does this PR do?**



- Lock Down Subcomponent version numbers for GSF 6.1.x in blank app seed
- Note: this limits the clients' ability to test other versions of GSF, this will be resolved by an [additional ticket](https://genesisglobal.atlassian.net/browse/PTC-464)

🚀 &nbsp; **Where should the reviewer start?**



see file diffs



📑 &nbsp; **How should this be tested?**



run genx from the command line and select blank-app-seed, ensure generated project builds



✅ &nbsp; **Checklist**



<!--- Review the list and put an x in the boxes that apply. -->


- [x] I have tested my changes.
- [ ] I have added tests for my changes.
- [x] I have updated the project documentation to reflect my changes.
