### PR TITLE
fix: Docker bug with line endings PTC-771

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.sh text eol=lf
+
+# Declare files that will always have CRLF line endings on checkout.
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

Related JIRA: https://genesisglobal.atlassian.net/browse/PTC-771


🤔 &nbsp; **What does this PR do?**

- Add the .gitattributes file to deal with Docker bug with line endings. Git can be used to define Global settings for line endings: Configuring Git to handle line endings - GitHub Docs - https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#global-settings-for-line-endings


🚀 &nbsp; **Where should the reviewer start?**

- Double-check the repo tree. There is only one new file: ,gitattribute, as stated above.


📑 &nbsp; **How should this be tested?**

- Clone this repo again. The files inside the path 'blank-app-seed/server/jvm/docker-scripts/' should have LF instead of CRLF (the root issue). You can use an IDE like [VSCode](https://github.com/microsoft/vscode/issues/24625) to see that.
- We also added the same file (.gitattributes)  in the dev training and looks like we are ok, and not relying on windows configuration anymore. Using the .gitattributes file, git converts CRLF to LF for you when checking the project out. 


✅ &nbsp; **Checklist**


<!--- Review the list and put an x in the boxes that apply. -->


- [ X ] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
