### PR TITLE
fix: Add genesis-config dependency so sysdef compiles on the IDE. PTC-694

### DIFF
--- a/server/jvm/genesis-site-specific/build.gradle.kts
+++ b/server/jvm/genesis-site-specific/build.gradle.kts
@@ -12,6 +12,9 @@ val distribution by configurations.creating {
     isCanBeConsumed = true
     isCanBeResolved = false
 }
+dependencies {
+    compileOnly("global.genesis:genesis-config")
+}
 distributions {
     main {
         contents {


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**



[PTC-694](https://genesisglobal.atlassian.net/browse/PTC-694)



🤔 &nbsp; **What does this PR do?**



- Fixes sysdef compilation issues 



📑 &nbsp; **How should this be tested?**
