### PR TITLE
fix: site specific publication now uses app name instead of being hard-coded (GSF-5947)

### DIFF
--- a/.genx/configure.js
+++ b/.genx/configure.js
@@ -104,8 +104,8 @@ module.exports = async (data, utils) => {
   /**
    * Configuring server projects
    */
-   writeFile(path.resolve(directory, "settings.gradle.kts"), data);
-   writeFile(path.resolve(directory, "docker-compose.yml"), data);
+  writeFile(path.resolve(directory, "settings.gradle.kts"), data);
+  writeFile(path.resolve(directory, "docker-compose.yml"), data);
 
   const serverJvmRoot = path.resolve(directory, "server", "jvm");
   const appNamePlaceholder = "genesis";
@@ -113,15 +113,16 @@ module.exports = async (data, utils) => {
 
   const listAllFilesIncSubDirs = (rootFolder, fileFilter, incSubDirectories) => {
     return klawSync(rootFolder, {
-        nodir: false,
+        nodir: !incSubDirectories,
         filter: fileFilter,
-        traverseAll: incSubDirectories
-    }).map((i) => i.path);
+    });
   };
 
-  const fileFilter = (item) => item.path.endsWith(".kts");
-  listAllFilesIncSubDirs(serverJvmRoot, fileFilter, true)
-      .forEach(filteredPath => { writeFile(filteredPath, data) });
+  const ignore = ['.DS_Store', '.gradle', '.lock', '.jar'];
+  const fileFilter = (item) => ignore.every((el) => !item.path.endsWith(el));
+  listAllFilesIncSubDirs(serverJvmRoot, fileFilter, true).forEach(item => {
+      !item.stats.isDirectory() && writeFile(item.path, data)
+  });
 
   const dictionaryConfigFolder = path.resolve(serverJvmRoot, "genesis-config", "src", "main", "resources", "cfg");
   move(path.resolve(dictionaryConfigFolder, "genesis-fields-dictionary.kts"), path.resolve(dictionaryConfigFolder, `${data.appName}-fields-dictionary.kts`));

--- a/.genx/configure.js
+++ b/.genx/configure.js
@@ -16,7 +16,7 @@ const fs = require('fs-extra')
  *    editJSONFile(path: string, options: any);
  *    readFile(file: PathOrFileDescriptor): string;
  *    writeFile(file: PathOrFileDescriptor, data: string): void;
- *    writeFileWithData(file: PathOrFileDescriptor, answers: inquirer.Answers): void;
+ *    writeFile(file: PathOrFileDescriptor, answers: inquirer.Answers): void;
  *    copyFiles(source: string, destination: string, options: CopyOptionsSync): void;
  *    copyFilesAsync(source: string, destination: string, options: CopyOptionsSync): Promise<void>;
  *    replaceObjectKeys(input: object, searchValue: string | RegExp, replaceValue: string): object;
@@ -26,10 +26,22 @@ const fs = require('fs-extra')
  */
 module.exports = async (data, utils) => {
   const {directory, pkgScope, pkgName, apiHost} = data;
-  const {editJSONFile, replaceObjectKeys, writeFileWithData} = utils;
+  const {editJSONFile, writeFileWithData} = utils;
   const prefixTarget = 'pkgScope/pkgName';
   const prefixReplacement = `${pkgScope}/${pkgName}-`;
   data.localGenId = data.appName.toUpperCase().replace("-", "_");
+
+  const writeFile = (file, data, template) => {
+    try {
+      const filePath = path.resolve(directory, file);
+      const templatePath = template ? path.resolve(directory, template) : undefined;
+      return writeFileWithData(filePath, data, templatePath);
+    } catch (e) {
+      console.error(`Error writing file ${file} using template ${template}`, e);
+      console.error('Data', data);
+      process.exit(1);
+    }
+  };
 
   /**
    * Write answers data for future use by the CLI
@@ -51,13 +63,13 @@ module.exports = async (data, utils) => {
   /**
    * Update the client root .npmrc file
    */
-  writeFileWithData(path.resolve(directory, 'client/.npmrc'), data, path.resolve(directory, '.genx/plop/templates/.npmrc.hbs'));
+  writeFile(path.resolve(directory, 'client/.npmrc'), data, path.resolve(directory, '.genx/plop/templates/.npmrc.hbs'));
 
   /**
    * Update the README.md files
    * TODO: Create handlebar templates for the README.md files in ./plop/templates due to re-configure re-runs
    */
-  writeFileWithData(path.resolve(directory, 'README.md'), data);
+  writeFile(path.resolve(directory, 'README.md'), data);
 
   /**
    * Update the names and dependencies of the lerna managed packages
@@ -91,18 +103,32 @@ module.exports = async (data, utils) => {
   /**
    * Configuring server projects
    */
-   writeFileWithData(path.resolve(directory, "settings.gradle.kts"), data);
-   writeFileWithData(path.resolve(directory, "docker-compose.yml"), data);
+   writeFile(path.resolve(directory, "settings.gradle.kts"), data);
+   writeFile(path.resolve(directory, "docker-compose.yml"), data);
 
   const serverJvmRoot = path.resolve(directory, "server", "jvm");
   const appNamePlaceholder = "genesis";
   const dictionaryCacheRoot = path.resolve(directory, "server", "jvm", "genesis-dictionary-cache");
 
-  utils.listAllFiles(serverJvmRoot, toFilter => {
-    return !toFilter.path.endsWith(".jar")
-  }).forEach(filteredPath => {
-    writeFileWithData(filteredPath, data);
-  });
+  // listAllFiles doesnt get subdirectories, so we never wrote to the genesis-* dirs before
+  let files = [];
+  const getFilesRecursively = (directory) => {
+    const filesInDirectory = fs.readdirSync(directory);
+    for (const file of filesInDirectory) {
+      const absolute = path.join(directory, file);
+      if (fs.statSync(absolute).isDirectory()) {
+        getFilesRecursively(absolute);
+      } else {
+        files.push(absolute);
+      }
+    }
+  };
+
+  getFilesRecursively(serverJvmRoot)
+
+  files.forEach(file => {
+    file.endsWith(".kts") && writeFile(file, data);
+  })
 
   const dictionaryConfigFolder = path.resolve(serverJvmRoot, "genesis-config", "src", "main", "resources", "cfg");
   move(path.resolve(dictionaryConfigFolder, "genesis-fields-dictionary.kts"), path.resolve(dictionaryConfigFolder, `${data.appName}-fields-dictionary.kts`));

--- a/server/jvm/genesis-site-specific/build.gradle.kts
+++ b/server/jvm/genesis-site-specific/build.gradle.kts
@@ -64,7 +64,7 @@ artifacts {
 }
 publishing {
     publications {
-        create<MavenPublication>("testSiteSpecificDistribution") {
+        create<MavenPublication>("{{appName}}SiteSpecificDistribution") {
             artifact(tasks.distZip.get())
         }
     }
@@ -74,7 +74,7 @@ artifactory {
     val targetRepoKey = "libs-${buildTagFor(project.version.toString())}-local"
     // Add all publication list to publicationNames
     // These are the necessary publications for everything genesis related.
-    val publicationNames = arrayOf("trinitySiteSpecificDistribution")
+    val publicationNames = arrayOf("{{appName}}SiteSpecificDistribution")
     publish(
         delegateClosureOf<org.jfrog.gradle.plugin.artifactory.dsl.PublisherConfig> {
             repository(


### PR DESCRIPTION
also fixed configure.js to actually write data to the genesis-* directories configure.js no longer attempts to write binary files, and handles errors with writing files (thanks artur)

[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**



[GSF-5947](https://genesisglobal.atlassian.net/browse/GSF-5947)



🤔 &nbsp; **What does this PR do?**



- Add bullets..



🚀 &nbsp; **Where should the reviewer start?**



Add file / directory pointers.



📑 &nbsp; **How should this be tested?**



Add testing suggestions, which apps to run, or storybook etc.



✅ &nbsp; **Checklist**



<!--- Review the list and put an x in the boxes that apply. -->


- [x] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
