### PR TITLE
fix: update login route configs to match latest foundation-login - FUI-1025

### DIFF
--- a/client/web/src/routes/config.ts
+++ b/client/web/src/routes/config.ts
@@ -7,7 +7,6 @@ import {
 } from '@genesislcap/foundation-comms';
 import {
   defaultLoginConfig,
-  Login,
   LoginConfig,
   Settings as LoginSettings,
 } from '@genesislcap/foundation-login';
@@ -36,15 +35,33 @@ export class MainRouterConfig extends RouterConfiguration<LoginSettings> {
     this.title = 'Blank App Demo';
     this.defaultLayout = defaultLayout;
 
+    const authPath = 'login';
+
     this.routes.map(
-      { path: '', redirect: 'login' },
+      { path: '', redirect: authPath },
       {
-        path: 'login',
-        element: Login,
-        title: 'Login',
+        path: authPath,
         name: 'login',
-        settings: { public: true },
+        title: 'Login',
+        element: async () => {
+          const { configure, define } = await import(
+            /* webpackChunkName: "foundation-login" */
+            '@genesislcap/foundation-login'
+          );
+          configure(this.container, {
+            autoConnect: true,
+            defaultRedirectUrl: 'home',
+          });
+          return define({
+            name: `blank-app-login`,
+            /**
+             * You can augment the template and styles here when needed.
+             */
+          });
+        },
         layout: loginLayout,
+        settings: { public: true },
+        childRouters: true,
       },
       { path: 'home', element: Home, title: 'Home', name: 'home' },
       { path: 'not-found', element: NotFound, title: 'Not Found', name: 'not-found' }
@@ -56,7 +73,7 @@ export class MainRouterConfig extends RouterConfiguration<LoginSettings> {
      * Example of a FallbackRouteDefinition
      */
     this.routes.fallback(() =>
-      this.auth.isLoggedIn ? { redirect: 'not-found' } : { redirect: 'login' }
+      this.auth.isLoggedIn ? { redirect: 'not-found' } : { redirect: authPath }
     );
 
     /**
@@ -98,7 +115,7 @@ export class MainRouterConfig extends RouterConfiguration<LoginSettings> {
          */
         phase.cancel(() => {
           this.session.captureReturnUrl();
-          Route.name.replace(phase.router, 'login');
+          Route.name.replace(phase.router, authPath);
         });
       },
     });


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**

[FUI-1025](https://genesisglobal.atlassian.net/browse/FUI-1025)

🤔 &nbsp; **What does this PR do?**

- Update `foundation-login` related configs used in the `routes/config.ts`
  - Latest version changes the way we load/configure the Login Microfrontend

🚀 &nbsp; **Where should the reviewer start?**

Right [here](https://github.com/genesiscommunitysuccess/blank-app-seed/pull/44/files#diff-0072d346d4b3bcb8f7dca51816bbaf551c41ff6539f02ac49ae1224b522fb78dR45)

📑 &nbsp; **How should this be tested?**

`develop` branch using the current versioning approach for `foundation-login` won't work properly when configuring some of the "Login Settings"

this branch will, try playing around with the [configure](https://github.com/genesiscommunitysuccess/blank-app-seed/pull/44/files#diff-0072d346d4b3bcb8f7dca51816bbaf551c41ff6539f02ac49ae1224b522fb78dR51) block.

✅ &nbsp; **Checklist**

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
