### PR TITLE
feat: bump server version to 6.5.5 FUI-1130

### DIFF
--- a/server/jvm/gradle.properties
+++ b/server/jvm/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx6g -Xss512k -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC -XX:+UseStringDeduplication -XX:ReservedCodeCacheSize=512m -Dkotlin.daemon.jvm.options=-Xmx2g -Dfile.encoding=UTF-8
 bundleGeneratedClasses=true
-genesisVersion=6.4.0
-authVersion=6.4.0
-deployPluginVersion=6.4.0
+genesisVersion=6.5.1
+authVersion=6.5.1
+deployPluginVersion=6.5.1

--- a/server/jvm/gradle.properties
+++ b/server/jvm/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx6g -Xss512k -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC -XX:+UseStringDeduplication -XX:ReservedCodeCacheSize=512m -Dkotlin.daemon.jvm.options=-Xmx2g -Dfile.encoding=UTF-8
 bundleGeneratedClasses=true
-genesisVersion=6.5.1
-authVersion=6.5.1
-deployPluginVersion=6.5.1
+genesisVersion=6.5.5
+authVersion=6.5.3
+deployPluginVersion=6.5.5


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**

FUI-1130

🤔 &nbsp; **What does this PR do?**

- Bumps server package versions to latest

🚀 &nbsp; **Where should the reviewer start?**



Add file / directory pointers.



📑 &nbsp; **How should this be tested?**

Create an app using local seed or `App seed Quick Start Application - Test` seed (only available with foundation-cli)
Build, run, check for any issues etc.

Running an with a few simple dataservers and event handlers:

```
***********************************************************************************************
                                        GENESIS Monitor
                                    Version:  GENESIS 6.5.1
***********************************************************************************************

Start: 2023-04-11 10:41:43                                                    Uptime: 9 minutes
Date:  2023-04-11 10:51:33                                                    Daemon status: OK

PID     Process Name                  Port        Status         CPU       Memory    Message
===============================================================================================
260     GENESIS_AUTH_CONSOLIDATOR     8005        STANDBY        4.90      4.40
150     GENESIS_AUTH_DATASERVER       8002        HEALTHY        10.10     5.90      ;Lmdb currently uses 1% of available space (total size 2GB)
113     GENESIS_AUTH_MANAGER          8001        HEALTHY        13.10     8.50
181     GENESIS_AUTH_PERMS            8003        HEALTHY        8.10      5.60
223     GENESIS_AUTH_REQUEST_SERVER   8004        HEALTHY        8.60      5.70
296     GENESIS_CLUSTER               9000        HEALTHY        14.00     8.80      ;Lmdb currently uses 1% of available space (total size 2GB)
334     GENESIS_ROUTER                9017        HEALTHY        7.40      7.20
===============================================================================================
396     ALPHA_DATASERVER              11000       HEALTHY        7.60      8.20      ;Lmdb currently uses 1% of available space (total size 2GB)
435     ALPHA_EVENT_HANDLER           11001       HEALTHY        8.00      6.50
469     ALPHA_REQUEST_SERVER          11002       HEALTHY        6.60      6.00
```

✅ &nbsp; **Checklist**



<!--- Review the list and put an x in the boxes that apply. -->


- [x] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
