### PR TITLE
fix: body font not being picked up by preview components in DSC app FUI-1432

### DIFF
--- a/client/web/src/styles/design-tokens.json
+++ b/client/web/src/styles/design-tokens.json
@@ -12,7 +12,7 @@
     },
     "fontFamily": {
       "bodyFont": {
-        "$value": "Roboto, 'Segoe UI', Arial, Helvetica, sans-serif",
+        "$value": "Roboto, \"Segoe UI\", Arial, Helvetica, sans-serif",
         "$type": "fontFamily"
       }
     },


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**


[FUI-1432](https://genesisglobal.atlassian.net/browse/FUI-1432)


🤔 &nbsp; **What does this PR do?**

- updates the body font value to the correct value used for Roboto Font family everywhere

![image](https://github.com/genesiscommunitysuccess/blank-app-seed/assets/118179643/453f3bd8-ddb7-4cf4-94c7-b786aafd302f)


🚀 &nbsp; **Where should the reviewer start?**

- review changes in src/styles/design-tokens.json


📑 &nbsp; **How should this be tested?**

- npm run bootstrap in client directory
- npm run configure-design-system in client/web director
 Once you have the DSC app running check if the Roboto family font is being applied as shown in above image.


```
npx -y @genesislcap/genx@latest init prtest -x --ref YOUR-BRANCH-NAME
```



✅ &nbsp; **Checklist**



<!--- Review the list and put an x in the boxes that apply. -->


- [x] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
