### PR TITLE
fix: Improve search criteria for getting latest version PSD-21

### DIFF
--- a/.genx/scripts/update-versions.js
+++ b/.genx/scripts/update-versions.js
@@ -20,8 +20,8 @@ const writeJSON = (json, path) => {
 };
 
 const UI = run('npm info @genesislcap/foundation-ui@latest version');
-const GSF = run(`jf rt s "libs-release-client/global/genesis/genesis-distribution/" --sort-by=created --sort-order=desc --limit=1 --exclusions="*-RC*;*-SNAPSHOT*" | grep path | tr -s ' ' | cut -d '/' -f 5`);
-const Auth = run(`jf rt s "libs-release-client/global/genesis/auth-distribution/" --sort-by=created --sort-order=desc --limit=1 --exclusions="*-RC*;*-SNAPSHOT*" | grep path | tr -s ' ' | cut -d '/' -f 5`);
+const GSF = run(`jf rt s "libs-release-client/global/genesis/genesis-distribution/" --sort-by="name;created" --sort-order=desc --limit=1 --exclusions="*-RC*;*-SNAPSHOT*;*maven-metadata*" | grep path | tr -s ' ' | cut -d '/' -f 5`);
+const Auth = run(`jf rt s "libs-release-client/global/genesis/auth-distribution/" --sort-by="name;created" --sort-order=desc --limit=1 --exclusions="*-RC*;*-SNAPSHOT*;*maven-metadata*" | grep path | tr -s ' ' | cut -d '/' -f 5`);
 const latest = { UI, GSF, Auth };
 
 console.log('Current:', current);


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**



[PSD-21](https://genesisglobal.atlassian.net/browse/PSD-21)



🤔 &nbsp; **What does this PR do?**


Improved search criteria for getting latest version
As it is observed that we released 6.6.5 version of AUTH after releasing 6.7.0 so sorting based on created date not necessarily gives the latest/highest version



🚀 &nbsp; **Where should the reviewer start?**



Add file / directory pointers.



📑 &nbsp; **How should this be tested?**



```
npx -y @genesislcap/genx@latest init prtest -x --ref YOUR-BRANCH-NAME
```



✅ &nbsp; **Checklist**



<!--- Review the list and put an x in the boxes that apply. -->


- [x] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
