### PR TITLE
fix: removed designTokens overwriting - FUI-1599

### DIFF
--- a/client/src/main/main.ts
+++ b/client/src/main/main.ts
@@ -36,12 +36,11 @@ export class MainApplication extends FASTElement {
   async connectedCallback() {
     super.connectedCallback();
     logger.debug(`${name} is now connected to the DOM`);
+    this.registerDIDependencies();
+    await this.loadRemotes();
     DOM.queueUpdate(() => {
       configureDesignSystem(this.provider, designTokens);
     });
-
-    this.registerDIDependencies();
-    await this.loadRemotes();
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**


[FUI-1599](https://genesisglobal.atlassian.net/browse/FUI-1599)


🤔 &nbsp; **What does this PR do?**



Changes the order of loading design tokens. Currently, they are loaded before importing zero-design-system-provider, which overwrites them with default values from Microsoft Fast Design.



🚀 &nbsp; **Where should the reviewer start?**



file: client\src\main\main.ts



📑 &nbsp; **How should this be tested?**



```
npx -y @genesislcap/genx@latest init prtest -x --ref ak/FUI-1599-fix-design-tokens
```
client\src\styles\design-tokens.json change luminance to **1**
![image](https://github.com/genesiscommunitysuccess/blank-app-seed/assets/5808873/bb4b071a-f609-46b1-90da-7b9eda4db727)

go to client folder and run 
```
npm run bootstrap && npm run dev
```
the application should run in '_LightMode_'
![image](https://github.com/genesiscommunitysuccess/blank-app-seed/assets/5808873/d26edbda-c68f-4c7b-94dc-8ad2f7970099)


✅ &nbsp; **Checklist**



<!--- Review the list and put an x in the boxes that apply. -->


- [x] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
