### PR TITLE
feat: Add HookStateStore = DB into new blank seeded apps

### DIFF
--- a/server/jvm/{{appName}}-site-specific/src/main/resources/cfg/genesis-system-definition.kts
+++ b/server/jvm/{{appName}}-site-specific/src/main/resources/cfg/genesis-system-definition.kts
@@ -13,6 +13,7 @@ systemDefinition {
         {{/if}}
         item(name = "DictionarySource", value = "DB")
         item(name = "AliasSource", value = "DB")
+        item(name = "HookStateStore", value = "DB")
         item(name = "MetricsEnabled", value = "false")
         item(name = "ZeroMQProxyInboundPort", value = "5001")
         item(name = "ZeroMQProxyOutboundPort", value = "5000")


### PR DESCRIPTION
Set this by default so new projects have the recommended setting from inset

`item(name = "HookStateStore", value = "DB")`

We can't set as the default value where not defined for historical reasons

[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**



[PTC-0](https://genesisglobal.atlassian.net/browse/PTC-0)



🤔 &nbsp; **What does this PR do?**



- Add bullets..



🚀 &nbsp; **Where should the reviewer start?**



Add file / directory pointers.



📑 &nbsp; **How should this be tested?**



```
npx -y @genesislcap/genx@latest init prtest -x --ref YOUR-BRANCH-NAME
```



✅ &nbsp; **Checklist**



<!--- Review the list and put an x in the boxes that apply. -->


- [ ] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
