### PR TITLE
fix: ensure .gitignore is included in NPM artifact PSD-47

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 20
 
       - name: Generate .npmignore
-        run: cp .gitignore .npmignore && echo '\n!.gitignore' >> .npmignore
+        run: cp .gitignore .npmignore && echo '!.gitignore' >> .npmignore
 
       - name: Release
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           node-version: 20
 
+      - name: Generate .npmignore
+        run: cp .gitignore .npmignore && echo '\n!.gitignore' >> .npmignore
+
       - name: Release
         env:
           GH_TOKEN: ${{secrets.GH_USER_TOKEN}}
@@ -29,17 +32,14 @@ jobs:
           npm install
           npm run release
 
-      - name: Generate .npmignore
-        run: cp .gitignore .npmignore && echo '\n!.gitignore' >> .npmignore
-
       - name: Echo .npmignore
-        run: echo .npmignore
+        run: cat .npmignore
 
       - name: Publish
         uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{secrets.NPM_TOKEN}}
-          dry: true
+          dry-run: true
 
       # - name: Set up JDK
       #   uses: actions/setup-java@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,65 +22,49 @@ jobs:
         with:
           node-version: 20
 
-      - name: Generate .npmignore
-        run: cp .gitignore .npmignore && echo '!.gitignore' >> .npmignore
-
-      - name: Release
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+      - uses: KengoTODA/actions-setup-docker-compose@main
         env:
-          GH_TOKEN: ${{secrets.GH_USER_TOKEN}}
-        run: |
-          npm install
-          npm run release
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-      - name: Echo .npmignore
-        run: cat .npmignore
+      - name: Configure Gradle
+        run: ./.genx/scripts/init-gradle.sh
 
-      - name: Publish
-        run: npm pack -dry
+      - name: Generate sample app
+        working-directory: /tmp
+        run: npx -y @genesislcap/genx@latest init testapp -s "${{github.workspace}}" -x
 
-      # - name: Set up JDK
-      #   uses: actions/setup-java@v3
-      #   with:
-      #     java-version: '17'
-      #     distribution: 'temurin'
-      #     cache: 'gradle'
-      # - uses: KengoTODA/actions-setup-docker-compose@main
-      #   env:
-      #     GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Copy fixtures
+        run: cp -R ./.genx/tests/fixtures/testapp/* /tmp/testapp
 
-      # - name: Configure Gradle
-      #   run: ./.genx/scripts/init-gradle.sh
+      - name: Build sample app
+        working-directory: /tmp/testapp
+        run: ./gradlew build -PclientSpecific=true
 
-      # - name: Generate sample app
-      #   working-directory: /tmp
-      #   run: npx -y @genesislcap/genx@latest init testapp -s "${{github.workspace}}" -x
+      - name: Lint UI
+        working-directory: /tmp/testapp/client
+        run: npm run lint
 
-      # - name: Copy fixtures
-      #   run: cp -R ./.genx/tests/fixtures/testapp/* /tmp/testapp
+      - name: Test (unit & integration UI)
+        working-directory: /tmp/testapp/client
+        run: npm run test && npm run test:e2e
 
-      # - name: Build sample app
-      #   working-directory: /tmp/testapp
-      #   run: ./gradlew build -PclientSpecific=true
+      - name: Skip binding to privileged port on CI
+        working-directory: /tmp/testapp
+        run: sed -i "s/- '443:443'/# - '443:443'/g" docker-compose.yml
 
-      # - name: Lint UI
-      #   working-directory: /tmp/testapp/client
-      #   run: npm run lint
+      - name: Create Server Dockerfile
+        working-directory: /tmp/testapp
+        run: ./gradlew :genesisproduct-testapp:testapp-deploy:createDockerfile
 
-      # - name: Test (unit & integration UI)
-      #   working-directory: /tmp/testapp/client
-      #   run: npm run test && npm run test:e2e
-
-      # - name: Skip binding to privileged port on CI
-      #   working-directory: /tmp/testapp
-      #   run: sed -i "s/- '443:443'/# - '443:443'/g" docker-compose.yml
-
-      # - name: Create Server Dockerfile
-      #   working-directory: /tmp/testapp
-      #   run: ./gradlew :genesisproduct-testapp:testapp-deploy:createDockerfile
-
-      # - name: Build Docker images
-      #   working-directory: /tmp/testapp
-      #   run: docker-compose build
+      - name: Build Docker images
+        working-directory: /tmp/testapp
+        run: docker-compose build
 
       # - name: Run healthcheck
       #   run: ./.genx/scripts/health-check.sh http://localhost:4569/health/status

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,49 +22,68 @@ jobs:
         with:
           node-version: 20
 
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
-      - uses: KengoTODA/actions-setup-docker-compose@main
+      - name: Release
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.GH_USER_TOKEN}}
+        run: |
+          npm install
+          npm run release
 
-      - name: Configure Gradle
-        run: ./.genx/scripts/init-gradle.sh
+      - name: Generate .npmignore
+        run: cp .gitignore .npmignore && echo '\n!.gitignore' >> .npmignore
 
-      - name: Generate sample app
-        working-directory: /tmp
-        run: npx -y @genesislcap/genx@latest init testapp -s "${{github.workspace}}" -x
+      - name: Echo .npmignore
+        run: echo .npmignore
 
-      - name: Copy fixtures
-        run: cp -R ./.genx/tests/fixtures/testapp/* /tmp/testapp
+      - name: Publish
+        uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{secrets.NPM_TOKEN}}
+          dry: true
 
-      - name: Build sample app
-        working-directory: /tmp/testapp
-        run: ./gradlew build -PclientSpecific=true
+      # - name: Set up JDK
+      #   uses: actions/setup-java@v3
+      #   with:
+      #     java-version: '17'
+      #     distribution: 'temurin'
+      #     cache: 'gradle'
+      # - uses: KengoTODA/actions-setup-docker-compose@main
+      #   env:
+      #     GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-      - name: Lint UI
-        working-directory: /tmp/testapp/client
-        run: npm run lint
+      # - name: Configure Gradle
+      #   run: ./.genx/scripts/init-gradle.sh
 
-      - name: Test (unit & integration UI)
-        working-directory: /tmp/testapp/client
-        run: npm run test && npm run test:e2e
+      # - name: Generate sample app
+      #   working-directory: /tmp
+      #   run: npx -y @genesislcap/genx@latest init testapp -s "${{github.workspace}}" -x
 
-      - name: Skip binding to privileged port on CI
-        working-directory: /tmp/testapp
-        run: sed -i "s/- '443:443'/# - '443:443'/g" docker-compose.yml
+      # - name: Copy fixtures
+      #   run: cp -R ./.genx/tests/fixtures/testapp/* /tmp/testapp
 
-      - name: Create Server Dockerfile
-        working-directory: /tmp/testapp
-        run: ./gradlew :genesisproduct-testapp:testapp-deploy:createDockerfile
+      # - name: Build sample app
+      #   working-directory: /tmp/testapp
+      #   run: ./gradlew build -PclientSpecific=true
 
-      - name: Build Docker images
-        working-directory: /tmp/testapp
-        run: docker-compose build
+      # - name: Lint UI
+      #   working-directory: /tmp/testapp/client
+      #   run: npm run lint
+
+      # - name: Test (unit & integration UI)
+      #   working-directory: /tmp/testapp/client
+      #   run: npm run test && npm run test:e2e
+
+      # - name: Skip binding to privileged port on CI
+      #   working-directory: /tmp/testapp
+      #   run: sed -i "s/- '443:443'/# - '443:443'/g" docker-compose.yml
+
+      # - name: Create Server Dockerfile
+      #   working-directory: /tmp/testapp
+      #   run: ./gradlew :genesisproduct-testapp:testapp-deploy:createDockerfile
+
+      # - name: Build Docker images
+      #   working-directory: /tmp/testapp
+      #   run: docker-compose build
 
       # - name: Run healthcheck
       #   run: ./.genx/scripts/health-check.sh http://localhost:4569/health/status

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,10 +36,7 @@ jobs:
         run: cat .npmignore
 
       - name: Publish
-        uses: JS-DevTools/npm-publish@v3
-        with:
-          token: ${{secrets.NPM_TOKEN}}
-          dry-run: true
+        run: npm pack -dry
 
       # - name: Set up JDK
       #   uses: actions/setup-java@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,10 @@ jobs:
           npm run release
 
       - name: Generate .npmignore
-        run: cp .gitignore .npmignore && echo '\n!.gitignore' >> .npmignore
+        run: cp .gitignore .npmignore && echo '!.gitignore' >> .npmignore && cat .npmignore
+
+      - name: NPM pack dry-run
+        run: npm pack -dry
 
       - name: Publish
         uses: JS-DevTools/npm-publish@v3

--- a/.releaserc
+++ b/.releaserc
@@ -41,7 +41,8 @@
     [
       "@semantic-release/npm",
       {
-        "npmPublish": false
+        "npmPublish": false,
+        "tarballDir": false
       }
     ],
     [


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**

https://genesisglobal.atlassian.net/browse/PSD-47

🤔 &nbsp; **What does this PR do?**

- `\n!.gitignore` -> `!.gitignore` newline character was added literally rather than as a new line

📑 &nbsp; **How should this be tested?**

```
git clone git@github.com:genesiscommunitysuccess/blank-app-seed.git --depth 1 --branch ac/PSD-47-2 prtest && \
cd prtest && \
cp .gitignore .npmignore && echo '!.gitignore' >> .npmignore && \
npm pack -dry
```

gitignore should be on the list:

```
npm notice 1.6kB   .gitignore
```

✅ &nbsp; **Checklist**



<!--- Review the list and put an x in the boxes that apply. -->


- [x] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
