### PR TITLE
chore: Make H2 the default DB in blank app seed(GENC-49)

### DIFF
--- a/server/{{appName}}-app/src/main/genesis/cfg/genesis-system-definition.kts
+++ b/server/{{appName}}-app/src/main/genesis/cfg/genesis-system-definition.kts
@@ -1,8 +1,8 @@
 systemDefinition {
     global {
         item(name = "DbLayer", value = "SQL")
-        item(name = "DictionarySource", value = "FILE")
-        item(name = "DbHost", value = "jdbc:h2:file:./server/h2/test;DB_CLOSE_DELAY=-1;NON_KEYWORDS=VALUE,KEY;AUTO_SERVER=TRUE")
+        item(name = "DictionarySource", value = "DB")
+        item(name = "DbHost", value = "jdbc:h2:file:~/{{appName}}/server/h2/test;DB_CLOSE_DELAY=-1;NON_KEYWORDS=VALUE,KEY;AUTO_SERVER=TRUE")
         item(name = "DbQuotedIdentifiers", value = true)
         item(name = "DEPLOYED_PRODUCT", value = "{{appName}}")
         item(name = "MqLayer", value = env["MQ_LAYER", "ZeroMQ"])


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**



[PSD-49](https://genesisglobal.atlassian.net/browse/PSD-49)



🤔 &nbsp; **What does this PR do?**

Change h2 DB url from relative to absolute as having relative creates multiple databases
Changed DictionarySource from FILE to DB as that initial change is not needed to use database as H2



🚀 &nbsp; **Where should the reviewer start?**



Add file / directory pointers.



📑 &nbsp; **How should this be tested?**



```
npx -y @genesislcap/genx@latest init prtest -x --ref YOUR-BRANCH-NAME
```



✅ &nbsp; **Checklist**



<!--- Review the list and put an x in the boxes that apply. -->


- [x] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
