### PR TITLE
fix: consistent route file and web component naming GENC-176

### DIFF
--- a/.genx/configure.js
+++ b/.genx/configure.js
@@ -26,7 +26,7 @@ module.exports = async (data, utils) => {
   // to be exposed via user prompt in the future
   data.useDocker = !!process.env.USE_DOCKER;
   data.routes.forEach(route => {
-    const routeName = route.name;
+    const routeName = utils.changeCase.paramCase(route.name);
     makeDirectory(path.resolve(data.directory,`client/src/routes/${routeName}`));
     utils.writeFileWithData(path.resolve(data.directory, `client/src/routes/${routeName}/${routeName}.ts`), {route}, path.resolve(data.directory, '.genx/templates/route.hbs'));
     utils.writeFileWithData(path.resolve(data.directory, `client/src/routes/${routeName}/${routeName}.template.ts`), {route}, path.resolve(data.directory, '.genx/templates/route.template.hbs'));

--- a/.genx/prompts/ui.js
+++ b/.genx/prompts/ui.js
@@ -19,11 +19,15 @@ module.exports = async (inquirer, prevAns = {}) => {
   ])
 
   let routesParsed;
-  try {
-    routesParsed = JSON.parse(routes);
-  } catch (error) {
-    console.error("Error parsing `routes` parameter as JSON:", error.message);
-    console.log("Falling back to the default routes value");
+  if (routes) {
+    try {
+      routesParsed = JSON.parse(routes);
+    } catch (error) {
+      console.error("Error parsing `routes` parameter as JSON:", error.message);
+      console.log("Falling back to the default routes value");
+      routesParsed = JSON.parse(defaultRoutes);
+    }
+  } else {
     routesParsed = JSON.parse(defaultRoutes);
   }
 

--- a/.genx/templates/route.hbs
+++ b/.genx/templates/route.hbs
@@ -1,9 +1,9 @@
 import { customElement, FASTElement } from '@microsoft/fast-element';
-import { {{pascalCase route.name}}Styles as styles } from './{{route.name}}.styles';
-import { {{pascalCase route.name}}Template as template } from './{{route.name}}.template';
+import { {{pascalCase route.name}}Styles as styles } from './{{kebabCase route.name}}.styles';
+import { {{pascalCase route.name}}Template as template } from './{{kebabCase route.name}}.template';
 
 @customElement({
-  name: '{{route.name}}-route',
+  name: '{{kebabCase route.name}}-route',
   template,
   styles,
 })

--- a/client/src/routes/config.ts
+++ b/client/src/routes/config.ts
@@ -10,7 +10,7 @@ import { Route } from '@microsoft/fast-router';
 import { defaultLayout, loginLayout } from '../layouts';
 import { NotFound } from './not-found/not-found';
 {{#each routes}}
-import { {{pascalCase this.name}} } from './{{this.name}}/{{this.name}}';
+import { {{pascalCase this.name}} } from './{{kebabCase this.name}}/{{kebabCase this.name}}';
 {{/each}}
 
 // eslint-disable-next-line
@@ -57,7 +57,7 @@ export class MainRouterConfig extends FoundationRouterConfiguration<LoginSetting
           );
           configure(this.container, {
             autoConnect: true,
-            defaultRedirectUrl: '{{routes.[0].name}}',
+            defaultRedirectUrl: '{{kebabCase routes.[0].name}}',
             ...ssoSettings,
           });
           return define({
@@ -74,10 +74,10 @@ export class MainRouterConfig extends FoundationRouterConfiguration<LoginSetting
       { path: 'not-found', element: NotFound, title: 'Not Found', name: 'not-found' },
       {{#each routes}}
       {
-        path: '{{this.name}}',
+        path: '{{kebabCase this.name}}',
         element: {{pascalCase this.name}},
         title: '{{sentenceCase this.name}}',
-        name: '{{this.name}}',
+        name: '{{kebabCase this.name}}',
         navItems: [
           {
             title: '{{sentenceCase this.name}}',


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**



[GENC-176](https://genesisglobal.atlassian.net/browse/GENC-176)



🤔 &nbsp; **What does this PR do?**

- changes in template to apply correct files names
- check if routes are provided before parsing, if not parse default routes


📑 &nbsp; **How should this be tested?**



route name with capital letter and space should end up with camelcase component name and kebabcase filenames/web component

```
npx -y @genesislcap/genx@latest init prtest -x --ref ms/GENC-176-generate-components --routes "[{ \"name\": \"My page\" }]" --no-npm
```


default route settings shouldn't throw error about parsing
```
npx -y @genesislcap/genx@latest init prtest3 -x --ref ms/GENC-176-generate-components --no-npm
```



✅ &nbsp; **Checklist**



<!--- Review the list and put an x in the boxes that apply. -->


- [x] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
