### PR TITLE
fix: make absolute app paths work with local seeds GENC-183

### DIFF
--- a/.genx/configure.js
+++ b/.genx/configure.js
@@ -1,13 +1,6 @@
 const versions = require('./versions.json');
-const path = require('path');
-const fs = require('fs');
-const directoryExists = (directory) => fs.existsSync(directory);
+const { registerPartials, generateRoute } = require('./utils');
 
-const makeDirectory = (directory) => {
-  if (!directoryExists(directory)) {
-    fs.mkdirSync(directory);
-  }
-};
 /**
  * Signature is `async (data: inquirer.Answers, utils: SeedConfigurationUtils)`
  */
@@ -19,18 +12,10 @@ module.exports = async (data, utils) => {
   data.applicationVersionWeb = data.applicationVersion.split('-').shift();
   data.versions = versions;
 
-  utils.registerPartial('smart-form', path.resolve(data.directory, '.genx/templates/form.hbs'))
-  utils.registerPartial('chart', path.resolve(data.directory, '.genx/templates/chart.hbs'))
-  utils.registerPartial('entity-manager', path.resolve(data.directory, '.genx/templates/entityManager.hbs'))
-  utils.registerPartial('grid-pro', path.resolve(data.directory, '.genx/templates/grid.hbs'))
-  // to be exposed via user prompt in the future
-  data.useDocker = !!process.env.USE_DOCKER;
+  registerPartials(utils);
+
   data.routes.forEach(route => {
-    const routeName = utils.changeCase.paramCase(route.name);
-    makeDirectory(path.resolve(data.directory,`client/src/routes/${routeName}`));
-    utils.writeFileWithData(path.resolve(data.directory, `client/src/routes/${routeName}/${routeName}.ts`), {route}, path.resolve(data.directory, '.genx/templates/route.hbs'));
-    utils.writeFileWithData(path.resolve(data.directory, `client/src/routes/${routeName}/${routeName}.template.ts`), {route}, path.resolve(data.directory, '.genx/templates/route.template.hbs'));
-    utils.writeFileWithData(path.resolve(data.directory, `client/src/routes/${routeName}/${routeName}.styles.ts`), {route}, path.resolve(data.directory, '.genx/templates/route.styles.hbs'));
-  })
+    generateRoute(route, utils);
+  });
 
 };

--- a/.genx/utils.js
+++ b/.genx/utils.js
@@ -1,0 +1,29 @@
+const {existsSync, mkdirSync} = require('node:fs');
+const { resolve } = require('node:path');
+
+const makeDirectory = (directory) => {
+  if (!existsSync(directory)) {
+    mkdirSync(directory);
+  }
+};
+
+const registerPartials = ({ registerPartial }) => {
+  registerPartial('smart-form', resolve(__dirname, 'templates/form.hbs'))
+  registerPartial('chart', resolve(__dirname, 'templates/chart.hbs'))
+  registerPartial('entity-manager', resolve(__dirname, 'templates/entityManager.hbs'))
+  registerPartial('grid-pro', resolve(__dirname, 'templates/grid.hbs'))
+};
+
+const generateRoute = (route, { writeFileWithData, changeCase }) => {
+  const routeName = changeCase.paramCase(route.name);
+  makeDirectory(resolve(data.directory, `client/src/routes/${routeName}`));
+  writeFileWithData(resolve(__dirname, `../client/src/routes/${routeName}/${routeName}.ts`), {route}, resolve(__dirname, 'templates/route.hbs'));
+  writeFileWithData(resolve(__dirname, `../client/src/routes/${routeName}/${routeName}.template.ts`), {route}, resolve(__dirname, 'templates/route.template.hbs'));
+  writeFileWithData(resolve(__dirname, `../client/src/routes/${routeName}/${routeName}.styles.ts`), {route}, resolve(__dirname, 'templates/route.styles.hbs'));
+};
+
+module.exports = {
+  makeDirectory,
+  registerPartials,
+  generateRoute
+};

--- a/.genx/utils.js
+++ b/.genx/utils.js
@@ -16,7 +16,7 @@ const registerPartials = ({ registerPartial }) => {
 
 const generateRoute = (route, { writeFileWithData, changeCase }) => {
   const routeName = changeCase.paramCase(route.name);
-  makeDirectory(resolve(data.directory, `client/src/routes/${routeName}`));
+  makeDirectory(resolve(__dirname, `../client/src/routes/${routeName}`));
   writeFileWithData(resolve(__dirname, `../client/src/routes/${routeName}/${routeName}.ts`), {route}, resolve(__dirname, 'templates/route.hbs'));
   writeFileWithData(resolve(__dirname, `../client/src/routes/${routeName}/${routeName}.template.ts`), {route}, resolve(__dirname, 'templates/route.template.hbs'));
   writeFileWithData(resolve(__dirname, `../client/src/routes/${routeName}/${routeName}.styles.ts`), {route}, resolve(__dirname, 'templates/route.styles.hbs'));

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,7 +29,7 @@ Add file / directory pointers.
 
 
 ```
-npx -y @genesislcap/genx@latest init prtest -x --ref YOUR-BRANCH-NAME
+npx -y @genesislcap/genx@latest init prtest -x --ref YOUR-BRANCH-NAME --no-npm
 ```
 
 


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**

https://genesisglobal.atlassian.net/browse/GENC-183

🤔 &nbsp; **What does this PR do?**

- As titled

🚀 &nbsp; **Where should the reviewer start?**

configure.js

📑 &nbsp; **How should this be tested?**

### 1. No routes JSON (default)

```
rm -rf prtest && \
npx -y @genesislcap/genx@latest init prtest -x --ref ac/GENC-183 --no-npm --apiHost 'wss://public-foundation.genesislab.global/gwf/'
```

### 2. Routes JSON provided

```
rm -rf prtest && \
npx -y @genesislcap/genx@latest init prtest -x --ref ac/GENC-183 --routes "[{ \"name\": \"My page\" }]" --no-npm --apiHost 'wss://public-foundation.genesislab.global/gwf/'
```

### 3. Absolute app path and local seed

```
rm -rf testdir && \
rm -rf prtestseed && \
git clone git@github.com:genesiscommunitysuccess/blank-app-seed.git --depth 1 --branch ac/GENC-183 prtestseed && \
mkdir -p testdir/subdir && \
npx -y @genesislcap/genx@latest init "`pwd`/testdir/subdir/testapp" -x --routes "[{ \"name\": \"My page\" }]" --no-npm --apiHost 'wss://public-foundation.genesislab.global/gwf/' -s ./prtestseed
```

✅ &nbsp; **Checklist**



<!--- Review the list and put an x in the boxes that apply. -->


- [x] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
