### PR TITLE
fix: create unique layout autosave key attribute GENC-266

### DIFF
--- a/.genx/configure.js
+++ b/.genx/configure.js
@@ -14,8 +14,10 @@ module.exports = async (data, utils) => {
 
   registerPartials(utils);
 
-  data.routes.forEach(route => {
-    generateRoute(route, utils);
-  });
+	data.routes
+		.map((route) => ({ ...route, layoutKey: `${route.name}_${Date.now()}` }))
+		.forEach((route) => {
+			generateRoute(route, utils);
+		});
 
 };

--- a/.genx/templates/route.template.hbs
+++ b/.genx/templates/route.template.hbs
@@ -3,7 +3,7 @@ import type { {{pascalCase route.name}} } from './{{kebabCase route.name}}';
 
 export const {{pascalCase route.name}}Template = html<{{pascalCase route.name}}>`
   {{#if route.tiles}}
-  <zero-layout auto-save-key="{{route.name}}">
+  <zero-layout auto-save-key="{{route.layoutKey}}">
       <zero-layout-region>
           {{#each route.tiles}}
           <zero-layout-item title="{{this.title}}">


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**



[GENC-266](https://genesisglobal.atlassian.net/browse/GENC-266)



🤔 &nbsp; **What does this PR do?**



- Uses the current date/time to create a unique layout autosave key
- This handles [this issue](https://learn.genesis.global/docs/web/dynamic-layout/foundation-layout/#invalidating-the-cache)



📑 &nbsp; **How should this be tested?**



```
npx -y @genesislcap/genx@latest init prtest -x --ref mw/GENC-266-unique-layout-key --routes '[{"name":"home","tiles":[{"title":"Entity manager tile","type":"entity-manager","config":{"resourceName":"ALL_COUNTERPARTYS","title":"Counterparty Management","updateEvent":"EVENT_COUNTERPARTY_MODIFY","deleteEvent":"EVENT_COUNTERPARTY_DELETE","createEvent":"EVENT_COUNTERPARTY_INSERT"}},{"title":"Form tile","type":"smart-form","config":{"resourceName":"EVENT_TRADE_INSERT"}}]},{"name":"page-2","tiles":[{"title":"Grid Tile","type":"grid-pro","config":{"resourceName":"ALL_POSITIONS"}},{"title":"Charts Tile 1","type":"chart","config":{"type":"line","resourceName":"ALL_POSITIONS","xField":"INSTRUMENT_NAME","yField":"VALUE"}},{"title":"Charts Tile 2","type":"chart","config":{"type":"pie","resourceName":"ALL_POSITIONS","xField":"INSTRUMENT_NAME","yField":"VALUE"}},{"title":"Charts Tile 3","type":"chart","config":{"type":"column","resourceName":"ALL_POSITIONS","xField":"INSTRUMENT_ID","yField":"VALUE"}}]}]' --apiHost 'wss://public-foundation.genesislab.global/gwf/'
```
Observe that the `auto-save-key` attributes on the generated layouts have the date and time appended


✅ &nbsp; **Checklist**



<!--- Review the list and put an x in the boxes that apply. -->


- [X] I have tested my changes.
- [X] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
