### PR TITLE
feat: support to generate empty data csvs (GENC-280)

### DIFF
--- a/.genx/configure.js
+++ b/.genx/configure.js
@@ -1,5 +1,5 @@
 const versions = require('./versions.json');
-const { registerPartials, generateRoute } = require('./utils');
+const { registerPartials, generateRoute, generateEmptyCsv } = require('./utils');
 
 /**
  * Signature is `async (data: inquirer.Answers, utils: SeedConfigurationUtils)`
@@ -19,5 +19,14 @@ module.exports = async (data, utils) => {
 		.forEach((route) => {
 			generateRoute(route, utils);
 		});
+
+  data.emptyCsvs
+    .map(entity => ({
+      name: entity.name.toUpperCase(),
+      fields: entity.fields.map( (field, index) => ({name: field.toUpperCase(), isLast: index === (entity.fields.length -1) }))
+    }))
+    .forEach(entity => {
+      generateEmptyCsv(entity, data.appName, utils);
+    });
 
 };

--- a/.genx/configure.js
+++ b/.genx/configure.js
@@ -20,7 +20,7 @@ module.exports = async (data, utils) => {
 			generateRoute(route, utils);
 		});
 
-  data.emptyCsvs
+  data.csv
     .map(entity => ({
       name: entity.name.toUpperCase(),
       fields: entity.fields.map( (field, index) => ({name: field.toUpperCase(), isLast: index === (entity.fields.length -1) }))

--- a/.genx/prompts.js
+++ b/.genx/prompts.js
@@ -12,7 +12,7 @@ module.exports = async (inquirer, prevAns = {}) => {
   License: ${license}`);
 
   const {apiHost, enableSSO} = await apiPrompts(inquirer, prevAns)
-  const {groupId, applicationVersion, enableDeployPlugin, emptyCsvs} = await genesisServerPrompts(inquirer, prevAns);
+  const {groupId, applicationVersion, enableDeployPlugin, csv} = await genesisServerPrompts(inquirer, prevAns);
   const {routes} = await uiPrompts(inquirer, prevAns);
 
   return {
@@ -22,6 +22,6 @@ module.exports = async (inquirer, prevAns = {}) => {
     groupId,
     applicationVersion,
     enableDeployPlugin,
-    emptyCsvs,
+    csv,
   };
 };

--- a/.genx/prompts.js
+++ b/.genx/prompts.js
@@ -12,7 +12,7 @@ module.exports = async (inquirer, prevAns = {}) => {
   License: ${license}`);
 
   const {apiHost, enableSSO} = await apiPrompts(inquirer, prevAns)
-  const {groupId, applicationVersion, enableDeployPlugin} = await genesisServerPrompts(inquirer, prevAns);
+  const {groupId, applicationVersion, enableDeployPlugin, emptyCsvs} = await genesisServerPrompts(inquirer, prevAns);
   const {routes} = await uiPrompts(inquirer, prevAns);
 
   return {
@@ -22,5 +22,6 @@ module.exports = async (inquirer, prevAns = {}) => {
     groupId,
     applicationVersion,
     enableDeployPlugin,
+    emptyCsvs,
   };
 };

--- a/.genx/prompts/server.js
+++ b/.genx/prompts/server.js
@@ -1,13 +1,13 @@
 const {mavenArtifactVersionRegex} = require('./validators');
 
-const parseemptyCsvs = (inputEntities) => {
+const parsecsv = (inputEntities) => {
   if (!inputEntities){
     return [];
   }
   try {
     return JSON.parse(inputEntities);
   } catch (error) {
-    console.error("Error parsing `emptyCsvs` parameter as JSON:", error.message);
+    console.error("Error parsing `csv` parameter as JSON:", error.message);
     return [];
   }
 }
@@ -17,7 +17,7 @@ module.exports = async (inquirer, prevAns = {}) => {
       groupId = prevAns.groupId,
       applicationVersion = prevAns.applicationVersion,
       enableDeployPlugin = prevAns.enableDeployPlugin,
-      emptyCsvs = prevAns.emptyCsvs,
+      csv = prevAns.csv,
     } = await inquirer.prompt([
       {
         name: 'groupId',
@@ -42,10 +42,10 @@ module.exports = async (inquirer, prevAns = {}) => {
         default: prevAns.enableDeployPlugin || false
       },
       {
-        name: 'emptyCsvs',
+        name: 'csv',
         type: 'input',
         message: 'Generate empty CSV for entities? (config in json format)',
-        when: !prevAns.emptyCsvs,
+        when: !prevAns.csv,
         default: '[]'
       },
     ]);
@@ -54,6 +54,6 @@ module.exports = async (inquirer, prevAns = {}) => {
       groupId,
       applicationVersion,
       enableDeployPlugin,
-      emptyCsvs: parseemptyCsvs(emptyCsvs)
+      csv: parsecsv(csv)
     };
   };

--- a/.genx/prompts/server.js
+++ b/.genx/prompts/server.js
@@ -1,10 +1,23 @@
 const {mavenArtifactVersionRegex} = require('./validators');
 
+const parseemptyCsvs = (inputEntities) => {
+  if (!inputEntities){
+    return [];
+  }
+  try {
+    return JSON.parse(inputEntities);
+  } catch (error) {
+    console.error("Error parsing `emptyCsvs` parameter as JSON:", error.message);
+    return [];
+  }
+}
+
 module.exports = async (inquirer, prevAns = {}) => {
     const {
       groupId = prevAns.groupId,
       applicationVersion = prevAns.applicationVersion,
-      enableDeployPlugin = prevAns.enableDeployPlugin
+      enableDeployPlugin = prevAns.enableDeployPlugin,
+      emptyCsvs = prevAns.emptyCsvs,
     } = await inquirer.prompt([
       {
         name: 'groupId',
@@ -28,10 +41,19 @@ module.exports = async (inquirer, prevAns = {}) => {
         when: prevAns.enableDeployPlugin === undefined,
         default: prevAns.enableDeployPlugin || false
       },
+      {
+        name: 'emptyCsvs',
+        type: 'input',
+        message: 'Generate empty CSV for entities? (config in json format)',
+        when: !prevAns.emptyCsvs,
+        default: '[]'
+      },
     ]);
+
     return {
       groupId,
       applicationVersion,
       enableDeployPlugin,
+      emptyCsvs: parseemptyCsvs(emptyCsvs)
     };
   };

--- a/.genx/templates/csv.hbs
+++ b/.genx/templates/csv.hbs
@@ -1,0 +1,1 @@
+{{#each entity.fields}}{{this.name}}{{#unless this.isLast }},{{/unless}}{{/each}}

--- a/.genx/utils.js
+++ b/.genx/utils.js
@@ -22,8 +22,13 @@ const generateRoute = (route, { writeFileWithData, changeCase }) => {
   writeFileWithData(resolve(__dirname, `../client/src/routes/${routeName}/${routeName}.styles.ts`), {route}, resolve(__dirname, 'templates/route.styles.hbs'));
 };
 
+const generateEmptyCsv = (entity, appName, { writeFileWithData }) => {
+  writeFileWithData(resolve(__dirname, `../server/{{appName}}-app/src/main/genesis/data/${entity.name}.csv`), {entity}, resolve(__dirname, 'templates/csv.hbs'));
+};
+
 module.exports = {
   makeDirectory,
   registerPartials,
-  generateRoute
+  generateRoute,
+  generateEmptyCsv,
 };


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**



[GENC-280](https://genesisglobal.atlassian.net/browse/GENC-280)




🤔 &nbsp; **What does this PR do?**



- Introduces a new parameter `emptyCsvs` that accepts a JSON array;
- When supplid this parameter will create empty csv under `src/main/genesis/data` folder for each Table provided.



🚀 &nbsp; **Where should the reviewer start?**



- server.js


📑 &nbsp; **How should this be tested?**



```

npx @genesislcap/genx@latest init csvtest --ref ferreirar/GENC-280 -x --emptyCsvs '[{"name": "trade", "fields": ["a", "B"]}, {"name": "position", "fields": ["id", "TYPE"]} ]' --no-shell



```



✅ &nbsp; **Checklist**



<!--- Review the list and put an x in the boxes that apply. -->


- [X] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
