### PR TITLE
fix: default HTML page title to app name GENC-375

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # for reference see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
 
-* @cistov @derekdon @MrBrunoWolff @skawian @kievitsp @jacinpoz @khouari1 @rafaelnferreira
+* @cistov @derekdon @MrBrunoWolff @skawian @kievitsp @jacinpoz @khouari1 @rafaelnferreira @matteematt

--- a/client/index.html
+++ b/client/index.html
@@ -9,7 +9,7 @@ https://handlebarsjs.com/
 }}
 <head>
     <meta charset="utf-8"/>
-    <title></title>
+    <title>{{capitalCase appName}}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     {{#if enableSSO}}
     <script src="/initSSO.js"></script>

--- a/client/index.html
+++ b/client/index.html
@@ -9,7 +9,7 @@ https://handlebarsjs.com/
 }}
 <head>
     <meta charset="utf-8"/>
-    <title>\{{htmlWebpackPlugin.options.title}}</title>
+    <title></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     {{#if enableSSO}}
     <script src="/initSSO.js"></script>

--- a/client/src/routes/config.ts
+++ b/client/src/routes/config.ts
@@ -39,7 +39,7 @@ export class MainRouterConfig extends FoundationRouterConfiguration<LoginSetting
 
   async configure() {
     this.configureAnalytics();
-    this.title = 'Blank App Demo';
+    this.title = '{{capitalCase appName}}';
     this.defaultLayout = defaultLayout;
 
     const authPath = 'login';

--- a/client/test/e2e/flows/001-protected.e2e.ts
+++ b/client/test/e2e/flows/001-protected.e2e.ts
@@ -2,5 +2,5 @@ import { expect } from '@genesislcap/foundation-testing/e2e';
 import { test } from '../fixture';
 
 test('expected page title', async ({ protectedPage, page }) => {
-  await expect(page).toHaveTitle(/Blank App Demo - Login - Login/);
+  await expect(page).toHaveTitle(/Testapp - Login - Login/);
 });


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**

https://genesisglobal.atlassian.net/browse/GENC-375

🤔 &nbsp; **What does this PR do?**

- As titled

📑 &nbsp; **How should this be tested?**

### Defaults


```
rm -rf blankappseedtest && npx -y @genesislcap/genx@latest init positions-app -x --ref ac/GENC-375 --no-npm
cat client/index.html | grep 'Positions App'
```

✅ &nbsp; **Checklist**



<!--- Review the list and put an x in the boxes that apply. -->


- [x] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
