### PR TITLE
chore: enabling selective upgrade for main/prelease branches (GENC-704)

### DIFF
--- a/.genx/scripts/update-versions.js
+++ b/.genx/scripts/update-versions.js
@@ -3,6 +3,18 @@ const { writeFileSync } = require('node:fs');
 const { resolve } = require('node:path');
 const current = require('../versions.json');
 
+const args = process.argv.slice(2);
+const patchOnly = args.indexOf("--patch-only") >= 0;
+const dryRun = args.indexOf("--dry-run") >= 0;
+
+const VERSION_REGEX = /\d+$/;
+
+const jfrogVersionMatcher = patchOnly ? current.GSF.replace(VERSION_REGEX, '*') : undefined;
+
+const npmVersionMatcher = patchOnly ? current.UI.replace(VERSION_REGEX, 'x') : 'latest';
+
+console.log('Running with: ', {patchOnly, dryRun, npmVersionMatcher, jfrogVersionMatcher})
+
 const run = (command) =>
   execSync(command, {
     stdio: ['pipe', 'pipe', 'ignore'],
@@ -20,22 +32,28 @@ const writeJSON = (json, path) => {
   }
 };
 
-const UI = run('npm info @genesislcap/foundation-ui@latest version');
+const UI = run(`npm info @genesislcap/foundation-ui@${npmVersionMatcher} version`);
+
 const GSF = run(
-  `jf rt s "libs-release-client/global/genesis/genesis-distribution/" --exclusions="*-RC*;*-SNAPSHOT*;*maven-metadata*;*test*;*TEST*" | grep path | tr -s ' ' | sed 's/"path": //g' | awk -F'/' '{print $(NF-1)}' | sort -V | tail -n 1`,
+  `jf rt s "libs-release-client/global/genesis/genesis-distribution/${jfrogVersionMatcher ?? ''}" --exclusions="*-RC*;*-SNAPSHOT*;*maven-metadata*;*test*;*TEST*" | grep path | tr -s ' ' | sed 's/"path": //g' | awk -F'/' '{print $(NF-1)}' | sort -V | tail -n 1`,
 );
+
 const Auth = run(
-  `jf rt s "libs-release-client/global/genesis/auth-distribution/" --exclusions="*-RC*;*-SNAPSHOT*;*maven-metadata*;*test*;*TEST*" | grep path | tr -s ' ' | sed 's/"path": //g' | awk -F'/' '{print $(NF-1)}' | sort -V | tail -n 1`,
+  `jf rt s "libs-release-client/global/genesis/auth-distribution/${jfrogVersionMatcher ?? ''}" --exclusions="*-RC*;*-SNAPSHOT*;*maven-metadata*;*test*;*TEST*" | grep path | tr -s ' ' | sed 's/"path": //g' | awk -F'/' '{print $(NF-1)}' | sort -V | tail -n 1`,
 );
 const latest = { UI, GSF, Auth };
 
 console.log('Current:', current);
 console.log('Latest:', latest);
 
-if (current.UI !== UI || current.GSF !== GSF || current.Auth !== Auth) {
+if (current.UI !== UI || current.GSF !== GSF) {
   console.log('Newer versions available');
   const path = resolve(__dirname, '../versions.json');
-  writeJSON(latest, path);
+  if (!dryRun) {
+    writeJSON(latest, path);
+  } else {
+    console.log('Dry run execution, versions will not be written.')
+  }
 } else {
   console.log('No newer versions available');
 }

--- a/.genx/scripts/update-versions.js
+++ b/.genx/scripts/update-versions.js
@@ -46,7 +46,7 @@ const latest = { UI, GSF, Auth };
 console.log('Current:', current);
 console.log('Latest:', latest);
 
-if (current.UI !== UI || current.GSF !== GSF) {
+if (current.UI !== UI || current.GSF !== GSF || current.Auth !== Auth) {
   console.log('Newer versions available');
   const path = resolve(__dirname, '../versions.json');
   if (!dryRun) {

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,17 +1,35 @@
-name: Upgrade
+name: Ω Workflow - Upgrade dependencies
 
 on:
-  workflow_dispatch: # Manual
-  schedule:
-    - cron: '0 9 * * 1' # Mondays 9AM UTC
+  workflow_call:
+    inputs:
+      branch:
+        type: string
+        required: true
+        description: The branch that will be attmped to be upgraded
+      patch-only:
+        type: boolean
+        required: false
+        description: Only update if there are newer patch versions
+    secrets:
+      GH_USER_TOKEN:
+        required: true
+      JFROG_LIBS_RELEASE_CLIENT_RO_USER:
+        required: true
+      JFROG_LIBS_RELEASE_CLIENT_RO_KEY:
+        required: true
 
 jobs:
   upgrade:
     runs-on: ubuntu-latest
     environment: deploy
+    env:
+      BRANCH: ${{ inputs.branch }}
+      PATCH_ARG: ${{ inputs.patch-only && '--patch-only' || '' }}
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.branch }}
           token: ${{secrets.GH_USER_TOKEN}}
 
       - name: Set up Node
@@ -29,7 +47,7 @@ jobs:
           jfrog config add --artifactory-url="https://genesisglobal.jfrog.io/artifactory" --user="${{ secrets.JFROG_LIBS_RELEASE_CLIENT_RO_USER }}" --password="${{ secrets.JFROG_LIBS_RELEASE_CLIENT_RO_KEY }}" --interactive=false
 
       - name: Update to latest versions if available
-        run: node .genx/scripts/update-versions
+        run: node .genx/scripts/update-versions ${PATCH_ARG}
 
       - name: Check for changes
         id: versions
@@ -39,10 +57,10 @@ jobs:
         if: steps.versions.outputs.CHANGED
         run: |
           git config --global user.email "ci@genesis.global" && git config --global user.name "CI"
-          git checkout -b chore-dep-update
+          git checkout -b chore-dep-update-${BRANCH}
           git add --all
           git commit -m "fix: automated dependency version update [skip-ci] PSD-9"
-          git push -f --set-upstream origin chore-dep-update
+          git push -f --set-upstream origin chore-dep-update-${BRANCH}
 
       - name: Raise PR
         if: steps.versions.outputs.CHANGED
@@ -75,5 +93,3 @@ jobs:
           EOT
 
           node /tmp/create-pr/index
-
-

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -6,7 +6,7 @@ on:
       branch:
         type: string
         required: true
-        description: The branch that will be attmped to be upgraded
+        description: The branch that will be upgraded
       patch-only:
         type: boolean
         required: false

--- a/.github/workflows/upgrade_main.yml
+++ b/.github/workflows/upgrade_main.yml
@@ -2,7 +2,6 @@ name: Upgrade main
 
 on:
   workflow_dispatch: # Manual
-  pull_request: # temp trigger
   schedule:
     - cron: '0 8 * * 1-5' # Weekdays 8AM UTC
 

--- a/.github/workflows/upgrade_main.yml
+++ b/.github/workflows/upgrade_main.yml
@@ -2,6 +2,7 @@ name: Upgrade main
 
 on:
   workflow_dispatch: # Manual
+  pull_request: # temp trigger
   schedule:
     - cron: '0 8 * * 1-5' # Weekdays 8AM UTC
 

--- a/.github/workflows/upgrade_main.yml
+++ b/.github/workflows/upgrade_main.yml
@@ -1,0 +1,19 @@
+name: Upgrade main
+
+on:
+  workflow_dispatch: # Manual
+  schedule:
+    - cron: '0 8 * * 1-5' # Weekdays 8AM UTC
+
+concurrency: upgrade-main
+
+jobs:
+  upgrade:
+    uses: ./.github/workflows/upgrade.yml
+    with: 
+      branch: main
+      patch-only: true
+    secrets:
+      GH_USER_TOKEN: ${{ secrets.GH_USER_TOKEN }}
+      JFROG_LIBS_RELEASE_CLIENT_RO_USER: ${{ secrets.JFROG_LIBS_RELEASE_CLIENT_RO_USER }}
+      JFROG_LIBS_RELEASE_CLIENT_RO_KEY: ${{ secrets.JFROG_LIBS_RELEASE_CLIENT_RO_KEY }}

--- a/.github/workflows/upgrade_prerelease.yml
+++ b/.github/workflows/upgrade_prerelease.yml
@@ -2,6 +2,7 @@ name: Upgrade prerelease
 
 on:
   workflow_dispatch: # Manual
+  pull_request: # temp trigger
   schedule:
     - cron: '0 8 * * 1-5' # Weekdays 8AM UTC
 

--- a/.github/workflows/upgrade_prerelease.yml
+++ b/.github/workflows/upgrade_prerelease.yml
@@ -1,0 +1,18 @@
+name: Upgrade prerelease
+
+on:
+  workflow_dispatch: # Manual
+  schedule:
+    - cron: '0 8 * * 1-5' # Weekdays 8AM UTC
+
+concurrency: upgrade-prerelease
+
+jobs:
+  upgrade:
+    uses: ./.github/workflows/upgrade.yml
+    with: 
+      branch: prerelease
+    secrets:
+      GH_USER_TOKEN: ${{ secrets.GH_USER_TOKEN }}
+      JFROG_LIBS_RELEASE_CLIENT_RO_USER: ${{ secrets.JFROG_LIBS_RELEASE_CLIENT_RO_USER }}
+      JFROG_LIBS_RELEASE_CLIENT_RO_KEY: ${{ secrets.JFROG_LIBS_RELEASE_CLIENT_RO_KEY }}

--- a/.github/workflows/upgrade_prerelease.yml
+++ b/.github/workflows/upgrade_prerelease.yml
@@ -2,7 +2,6 @@ name: Upgrade prerelease
 
 on:
   workflow_dispatch: # Manual
-  pull_request: # temp trigger
   schedule:
     - cron: '0 8 * * 1-5' # Weekdays 8AM UTC
 


### PR DESCRIPTION
# What it is
- Splits the daily dependency upgrade worklfow into two:
1. Runs against `prerelease` and grabs the latest versions;
2. Runs against `main` and only grabs patch versions.

## Testing

Tested the script locally with the `--dry-run` parameter.
Workflows compile but they don't have permission to run in the dev branch (as they should).