### PR TITLE
feat: use public path for navigation when available FUI-2071

### DIFF
--- a/client-tmp/web-components/src/routes/config.ts
+++ b/client-tmp/web-components/src/routes/config.ts
@@ -1,6 +1,7 @@
 import { Auth, Session } from '@genesislcap/foundation-comms';
 import { defaultLoginConfig, LoginConfig } from '@genesislcap/foundation-login';
 import { FoundationRouterConfiguration } from '@genesislcap/foundation-ui';
+import { PUBLIC_PATH } from '@genesislcap/foundation-utils';
 import { NavigationPhase, optional, Route } from '@genesislcap/web-core';
 import { defaultLayout, loginLayout } from '../layouts';
 import { logger } from '../utils';
@@ -24,6 +25,8 @@ const ssoSettings =
         },
       }
     : {};
+
+const publicPath = typeof PUBLIC_PATH !== 'undefined' ? PUBLIC_PATH : '';
 
 export class MainRouterConfig extends FoundationRouterConfiguration<LoginSettings> {
   constructor(
@@ -56,7 +59,7 @@ export class MainRouterConfig extends FoundationRouterConfiguration<LoginSetting
           configure(this.container, {
             hostPath: 'login',
             autoConnect: true,
-            defaultRedirectUrl: '{{kebabCase routes.[0].name}}',
+            defaultRedirectUrl: publicPath + '{{kebabCase routes.[0].name}}',
             ...ssoSettings,
           });
           return define({


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**



[FUI-2071](https://genesisglobal.atlassian.net/browse/PTC-0)



🤔 &nbsp; **What does this PR do?**



- uses public path when it's specified to navigate to correct route




📑 &nbsp; **How should this be tested?**

In launchpad you can run the latest version and login redirect wouldn't navigate to the page. Add code from this PR to test correct navigation using public path.




✅ &nbsp; **Checklist**



<!--- Review the list and put an x in the boxes that apply. -->


- [x] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
