### PR TITLE
fix: bdd tests config to run against the server rather than via the UI GENC-1012

### DIFF
--- a/bdd-tests/src/test/resources/4-config/config.properties
+++ b/bdd-tests/src/test/resources/4-config/config.properties
@@ -1,8 +1,8 @@
 #BROWSER
 browser=chrome
 #ENVIRONMENT
-defaultHost=http://localhost:6060/
-baseURI=sm
+defaultHost=http://localhost:9064/
+baseURI=
 getEventAfterLogout=REQ_USER_DETAILS
 #PATH FOR RESOURCES
 resourcesPath=src/test/resources


### PR DESCRIPTION
Currently the default config for the BDD tests have the bdd tests running against `localhost:6060/sm` which is hitting the UI and then the reverse proxy, the `/sm` route then reroutes it to the server

This causes issues when we want to do things like validate the event handlers in Create - we're only running the server but this config requires us to run the UI too. 

This PR changes it so the BDD config hits the server directly and therefore doesn't require the UI to run. 