### PR TITLE
chore: remove connection logic from pbc renderer as not necessary

### DIFF
--- a/client-tmp/react/src/pbc/elementsRenderer.tsx
+++ b/client-tmp/react/src/pbc/elementsRenderer.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { AppElementPredicate, AppTargetId } from '@genesislcap/foundation-shell/app';
 import { customEventFactory, getTargetElements } from './utils';
-import { DI } from '@genesislcap/web-core';
-import { Connect } from '@genesislcap/foundation-comms';
 
 const ALWAYS_TRUE_PREDICATE: AppElementPredicate = () => true;
 
@@ -17,16 +15,6 @@ interface PBCContainerElement extends HTMLDivElement {
 
 const PBCElementsRenderer = ({ target = [], predicate = ALWAYS_TRUE_PREDICATE }: PBCElementsRendererProps) => {
   const containerRef = useRef<PBCContainerElement>(null);
-  const [isConnected, setIsConnected] = useState(false);
-
-  useEffect(() => {
-    const connect = DI.getOrCreateDOMContainer().get(Connect);
-    setIsConnected(connect.isConnected);
-    const isConnected$ = (connect as { isConnected$?: { subscribe: (cb: (v: boolean) => void) => { unsubscribe: () => void } } })
-      ?.isConnected$;
-    const sub = isConnected$?.subscribe((connected: boolean) => setIsConnected(connected));
-    return () => sub?.unsubscribe?.();
-  }, []);
 
   useEffect(() => {
     if (containerRef.current) {
@@ -37,7 +25,6 @@ const PBCElementsRenderer = ({ target = [], predicate = ALWAYS_TRUE_PREDICATE }:
   }, []);
 
   useEffect(() => {
-    if (!isConnected) return;
     if (containerRef.current) {
       containerRef.current.replaceChildren();
     }
@@ -47,7 +34,7 @@ const PBCElementsRenderer = ({ target = [], predicate = ALWAYS_TRUE_PREDICATE }:
         currentTemplate.render(containerRef.current, containerRef.current);
       }
     });
-  }, [target, predicate, isConnected]);
+  }, [target, predicate]);
 
   return (<div ref={containerRef} className="container"></div>);
 };


### PR DESCRIPTION
The only renderer of the PBC logic is via the DefaultLayout which already gates rendering on connection