### PR TITLE
feat: add default error boundary for React generated apps

### DIFF
--- a/.genx/templates/react/route.hbs
+++ b/.genx/templates/react/route.hbs
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import { Layout, Model, TabNode } from 'flexlayout-react';
 import { getFlexLayoutStorageKey } from '../../utils/layout';
+import { TileErrorBoundary } from '../../components/error-boundary/ErrorBoundary';
 {{#each route.tiles}}
 import { {{pascalCase this.componentName}} } from './{{pascalCase this.title}}{{pascalCase this.componentType}}';
 {{/each}}
@@ -31,7 +32,14 @@ const {{pascalCase route.name}} = () => {
 
   const factory = (node: TabNode) => {
     const Component = componentMap[node.getComponent() ?? ''];
-    return Component ? <Component /> : null;
+    return Component ? (
+      <TileErrorBoundary
+        title={node.getName() ?? node.getComponent() ?? ''}
+        tileRegistration={node.getComponent() ?? ''}
+      >
+        <Component />
+      </TileErrorBoundary>
+    ) : null;
   };
 
   const onModelChange = (model: Model) => {

--- a/client-tmp/react/src/components/error-boundary/ErrorBoundary.tsx
+++ b/client-tmp/react/src/components/error-boundary/ErrorBoundary.tsx
@@ -1,0 +1,250 @@
+import React, { useState } from 'react';
+import { errorBoundaryStyles } from './ErrorBoundaryStyles';
+
+type ErrorBoundaryScope = 'application' | 'tile';
+
+type ErrorBoundaryFallbackProps = {
+  scope: ErrorBoundaryScope;
+  referenceId: string;
+  title: string;
+  subtitle: string;
+  details: string;
+  onRetry: () => void;
+};
+
+type BaseErrorBoundaryProps = {
+  scope: ErrorBoundaryScope;
+  title: string;
+  tileRegistration?: string;
+  children: React.ReactNode;
+};
+
+type BaseErrorBoundaryState = {
+  hasError: boolean;
+  error: Error | null;
+  componentStack: string;
+  capturedAt: string;
+  referenceId: string;
+};
+
+const initialBoundaryState: BaseErrorBoundaryState = {
+  hasError: false,
+  error: null,
+  componentStack: '',
+  capturedAt: '',
+  referenceId: '',
+};
+
+const toError = (value: unknown): Error => {
+  if (value instanceof Error) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return new Error(value);
+  }
+
+  try {
+    return new Error(JSON.stringify(value));
+  } catch {
+    return new Error('Unknown non-serializable error');
+  }
+};
+
+const createReferenceId = (): string => {
+  const timestamp = new Date().toISOString().split(':').join('-');
+  const random = Math.random().toString(36).slice(2, 8).toUpperCase();
+  return `APP-${timestamp}-${random}`;
+};
+
+const ErrorBoundaryFallback: React.FC<ErrorBoundaryFallbackProps> = ({
+  scope,
+  referenceId,
+  title,
+  subtitle,
+  details,
+  onRetry,
+}) => {
+  const [copied, setCopied] = useState(false);
+  const [copyHelpVisible, setCopyHelpVisible] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(details);
+      setCopied(true);
+      setCopyHelpVisible(false);
+      window.setTimeout(() => {
+        setCopied(false);
+      }, 2_000);
+    } catch {
+      setCopyHelpVisible(true);
+    }
+  };
+
+  return (
+    <section className="error-boundary" role="alert">
+      <style>{errorBoundaryStyles}</style>
+      <div className="error-boundary__top">
+        <span className="error-boundary__status">
+          {scope === 'application' ? 'Application incident' : 'Tile incident'}
+        </span>
+        <span className="error-boundary__reference">Ref: {referenceId}</span>
+      </div>
+      <h2 className="error-boundary__title">{title}</h2>
+      <p className="error-boundary__subtitle">{subtitle}</p>
+      <p className="error-boundary__hint">
+        Tip: copy diagnostics and paste directly into Cursor to speed up debugging.
+      </p>
+      <textarea
+        className="error-boundary__details"
+        readOnly
+        value={details}
+        aria-label="Error diagnostics details"
+      />
+      <div className="error-boundary__actions">
+        <button type="button" className="error-boundary__button" onClick={onRetry}>
+          Retry
+        </button>
+        <button
+          type="button"
+          className="error-boundary__button error-boundary__button--secondary"
+          onClick={handleCopy}
+        >
+          {copied ? 'Copied' : 'Copy diagnostics'}
+        </button>
+      </div>
+      {copyHelpVisible ? (
+        <p className="error-boundary__manual-copy-help">
+          Clipboard access is blocked in this browser context. Please select the diagnostics text
+          and copy it manually.
+        </p>
+      ) : null}
+    </section>
+  );
+};
+
+class BaseErrorBoundary extends React.Component<BaseErrorBoundaryProps, BaseErrorBoundaryState> {
+  public constructor(props: BaseErrorBoundaryProps) {
+    super(props);
+    this.state = initialBoundaryState;
+  }
+
+  public static getDerivedStateFromError(error: unknown): Partial<BaseErrorBoundaryState> {
+    const normalized = toError(error);
+    return {
+      hasError: true,
+      error: normalized,
+      capturedAt: new Date().toISOString(),
+      referenceId: createReferenceId(),
+    };
+  }
+
+  public componentDidCatch(error: unknown, errorInfo: React.ErrorInfo): void {
+    const normalized = toError(error);
+    this.setState({
+      componentStack: errorInfo.componentStack ?? '',
+    });
+
+    console.error(`[${this.props.scope}] error boundary captured an error`, {
+      referenceId: this.state.referenceId,
+      title: this.props.title,
+      tileRegistration: this.props.tileRegistration,
+      error: normalized,
+      componentStack: errorInfo.componentStack,
+    });
+  }
+
+  private readonly handleRetry = (): void => {
+    this.setState(initialBoundaryState);
+  };
+
+  public render(): React.ReactNode {
+    if (!this.state.hasError || !this.state.error) {
+      return this.props.children;
+    }
+
+    const { scope, title, tileRegistration } = this.props;
+    const diagnostics = [
+      `Reference: ${this.state.referenceId}`,
+      `Scope: ${scope}`,
+      `Title: ${title}`,
+      `Tile registration: ${tileRegistration ?? 'N/A'}`,
+      `Captured at: ${this.state.capturedAt}`,
+      `URL: ${window.location.href}`,
+      `User agent: ${window.navigator.userAgent}`,
+      `Error name: ${this.state.error.name}`,
+      `Error message: ${this.state.error.message}`,
+      'Error stack:',
+      this.state.error.stack ?? 'No stack available',
+      'Component stack:',
+      this.state.componentStack || 'No component stack available',
+    ].join('\n');
+
+    const fallbackTitle =
+      scope === 'application'
+        ? 'Something went wrong'
+        : `Something went wrong in "${title}"`;
+    const fallbackSubtitle =
+      scope === 'application'
+        ? 'The app hit an unexpected error. You can retry or copy diagnostics for a fast fix.'
+        : 'This tile crashed, but the rest of the application keeps running. Retry or copy diagnostics.';
+
+    return (
+      <ErrorBoundaryFallback
+        scope={scope}
+        referenceId={this.state.referenceId}
+        title={fallbackTitle}
+        subtitle={fallbackSubtitle}
+        details={diagnostics}
+        onRetry={this.handleRetry}
+      />
+    );
+  }
+}
+
+type AppErrorBoundaryProps = {
+  children: React.ReactNode;
+};
+
+export const AppErrorBoundary: React.FC<AppErrorBoundaryProps> = ({ children }) => {
+  return (
+    <BaseErrorBoundary scope="application" title="Application">
+      {children}
+    </BaseErrorBoundary>
+  );
+};
+
+type TileErrorBoundaryProps = {
+  title: string;
+  tileRegistration: string;
+  children: React.ReactNode;
+};
+
+export const TileErrorBoundary: React.FC<TileErrorBoundaryProps> = ({
+  title,
+  tileRegistration,
+  children,
+}) => {
+  return (
+    <BaseErrorBoundary scope="tile" title={title} tileRegistration={tileRegistration}>
+      {children}
+    </BaseErrorBoundary>
+  );
+};
+
+export const withTileErrorBoundary = (
+  Component: React.ComponentType,
+  title: string,
+  tileRegistration: string,
+): React.FC => {
+  const WrappedWithErrorBoundary: React.FC = () => {
+    return (
+      <TileErrorBoundary title={title} tileRegistration={tileRegistration}>
+        <Component />
+      </TileErrorBoundary>
+    );
+  };
+
+  WrappedWithErrorBoundary.displayName = `WithTileErrorBoundary(${title}:${tileRegistration}:${Component.displayName || Component.name || 'TileComponent'})`;
+  return WrappedWithErrorBoundary;
+};

--- a/client-tmp/react/src/components/error-boundary/ErrorBoundaryStyles.ts
+++ b/client-tmp/react/src/components/error-boundary/ErrorBoundaryStyles.ts
@@ -1,0 +1,161 @@
+export const errorBoundaryStyles = `
+.error-boundary,
+.error-boundary__tile-wrap {
+  width: 100%;
+  height: 100%;
+}
+
+.error-boundary {
+  --eb-bg: #f6f8fb;
+  --eb-surface: #ffffff;
+  --eb-text: #18212f;
+  --eb-text-muted: #5f6f84;
+  --eb-border: #d3dae6;
+  --eb-accent: #2f6fed;
+  --eb-accent-hover: #255dcc;
+  --eb-accent-foreground: #ffffff;
+  --eb-error: #c53d3d;
+  --eb-focus: #2f6fed;
+  --eb-font: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 16px;
+  background: var(--eb-bg);
+  color: var(--eb-text);
+}
+
+.error-boundary__top,
+.error-boundary__title,
+.error-boundary__subtitle,
+.error-boundary__hint,
+.error-boundary__details,
+.error-boundary__actions,
+.error-boundary__manual-copy-help {
+  width: 100%;
+}
+
+.error-boundary__top {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.error-boundary__status {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--eb-error);
+  border-radius: 999px;
+  padding: 5px 10px;
+  font-family: var(--eb-font);
+  text-transform: uppercase;
+  letter-spacing: 0.13em;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--eb-error);
+  background: #fff4f4;
+}
+
+.error-boundary__reference {
+  font-family: 'Menlo', 'Consolas', 'Liberation Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--eb-text-muted);
+  text-transform: uppercase;
+}
+
+.error-boundary__title {
+  margin: 0;
+  font-family: var(--eb-font);
+  font-size: clamp(22px, 3vw, 30px);
+  line-height: 1.15;
+  font-weight: 700;
+  color: var(--eb-text);
+  text-wrap: balance;
+}
+
+.error-boundary__subtitle {
+  margin: 0;
+  max-width: 80ch;
+  font-family: var(--eb-font);
+  color: var(--eb-text);
+  line-height: 1.45;
+}
+
+.error-boundary__hint {
+  margin: -2px 0 2px;
+  font-family: var(--eb-font);
+  color: var(--eb-text-muted);
+  font-size: 13px;
+}
+
+.error-boundary__details {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 190px;
+  max-height: 360px;
+  padding: 12px;
+  border: 1px solid var(--eb-border);
+  border-radius: 10px;
+  background: var(--eb-surface);
+  color: var(--eb-text);
+  font-family: 'Menlo', 'Consolas', 'Liberation Mono', 'Courier New', monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.error-boundary__actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.error-boundary__button {
+  border: 1px solid var(--eb-accent);
+  border-radius: 999px;
+  background: var(--eb-accent);
+  color: var(--eb-accent-foreground);
+  cursor: pointer;
+  padding: 9px 16px;
+  font-family: var(--eb-font);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: transform 180ms ease, background-color 180ms ease;
+}
+
+.error-boundary__button--secondary {
+  border-color: var(--eb-border);
+  background: var(--eb-surface);
+  color: var(--eb-text);
+}
+
+.error-boundary__button:hover {
+  background: var(--eb-accent-hover);
+  transform: translateY(-1px);
+}
+
+.error-boundary__button--secondary:hover {
+  background: #eef2f8;
+}
+
+.error-boundary__button:focus-visible {
+  outline: 2px solid var(--eb-focus);
+  outline-offset: 2px;
+}
+
+.error-boundary__manual-copy-help {
+  margin: 2px 0 0;
+  font-size: 13px;
+  color: var(--eb-text-muted);
+  line-height: 1.4;
+}
+`;

--- a/client-tmp/react/src/main.tsx
+++ b/client-tmp/react/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
+import { AppErrorBoundary } from './components/error-boundary/ErrorBoundary'
 
 import { registerPBCs } from './pbc/utils';
 import { createLogger } from '@genesislcap/foundation-logger';
@@ -16,7 +17,9 @@ function bootstrapApp() {
   if (rootEelement) {
     ReactDOM.createRoot(rootEelement!).render(
       <React.StrictMode>
-        <App rootElement={rootEelement} />
+        <AppErrorBoundary>
+          <App rootElement={rootEelement} />
+        </AppErrorBoundary>
       </React.StrictMode>,
     )
   }


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**



[FUI-0](https://genesisglobal.atlassian.net/browse/FUI-0)



🤔 &nbsp; **What does this PR do?**



- Adds a production-ready `ErrorBoundary` implementation to the React seed so every app generated from blank-app-seed gets error boundary protection out of the box
- `AppErrorBoundary` wraps the entire app at the React root (`main.tsx`) — any unhandled render error shows a full-page fallback instead of a white screen
- `TileErrorBoundary` wraps each tile inside the FlexLayout `factory` function in the generated route template (`route.hbs`) — a crash in one tile is isolated and the rest of the app keeps running
- The fallback UI shows a reference ID (`APP-<timestamp>-<random>`), error title, diagnostic textarea (error stack + component stack + URL + user agent), a **Retry** button that resets the boundary, and a **Copy diagnostics** button for fast debugging



🚀 &nbsp; **Where should the reviewer start?**



- `client-tmp/react/src/components/error-boundary/ErrorBoundary.tsx` — the core implementation (`BaseErrorBoundary` class, `ErrorBoundaryFallback` UI, `AppErrorBoundary`, `TileErrorBoundary`, `withTileErrorBoundary` HOC)
- `client-tmp/react/src/components/error-boundary/ErrorBoundaryStyles.ts` — self-contained CSS-in-JS styles injected via `<style>` tag
- `client-tmp/react/src/main.tsx` — `AppErrorBoundary` wrapping `<App>` at the root
- `.genx/templates/react/route.hbs` — `TileErrorBoundary` added to the `factory` function so it applies to every generated route



📑 &nbsp; **How should this be tested?**

### Defaults

Generate an app with multiple tiles — this single app is used for all error boundary tests below:

```
rm -rf blankappseedtest && npx -y @genesislcap/genx@latest init blankappseedtest --ref sz/default-error-boundary --framework react --no-npm -x --routes '[{"name":"Home","icon":"house","tiles":[{"title":"Entity manager","type":"entity-manager","config":{"resourceName":"ALL_POSITIONS","title":"My Positions","updateEvent":"EVENT_COUNTERPARTY_MODIFY","deleteEvent":"EVENT_COUNTERPARTY_DELETE","createEvent":"EVENT_COUNTERPARTY_INSERT"}},{"title":"Grid","type":"grid-pro","config":{"resourceName":"ALL_TRADES"}}]}]' --no-shell && cd blankappseedtest/client && npm run bootstrap && npm run dev
```

### Test AppErrorBoundary (app-level crash)

Open `blankappseedtest/client/src/App.tsx` and add a throw at the top of the component body:

```tsx
const App: React.FC<AppProps> = ({ rootElement }) => {
  throw new Error("Test app-level error");
  // ...
```

Verify:
- The full-page error fallback renders with an **"Application incident"** badge
- A reference ID starting with `APP-` is shown
- The diagnostics textarea contains the error message, stack trace, and component stack
- **Retry** button resets the boundary and the app re-renders
- **Copy diagnostics** copies the text to clipboard

Revert the throw before continuing.

### Test TileErrorBoundary (per-tile crash isolation)

Open the generated `blankappseedtest/client/src/pages/Home/EntityManagerComponent.tsx` and add a throw:

```tsx
export const EntityManagerComponent: React.FC = () => {
  throw new Error("Test tile-level error");
  // ...
```

Verify:
- Only the crashing tile shows the **"Tile incident"** fallback
- The Grid tile continues to render and function normally
- The fallback shows the tile name and an `APP-` reference ID
- **Retry** resets just that tile

Revert the throw.

### Design tokens and header logo parameter handling test

```
rm -rf blankappseedtest && npx -y @genesislcap/genx@latest init blankappseedtest -x --ref sz/default-error-boundary --no-npm --designTokens '{"design_tokens":{"color":{"accent":{"$value":"#0EAFE2","$type":"color"},"neutral":{"$value":"#7C909B","$type":"color"}},"fontFamily":{"bodyFont":{"$value":"Roboto, \"Segoe UI\", Arial, Helvetica, sans-serif","$type":"fontFamily"}},"typography":{"baseFontSize":{"$value":"14px","$type":"dimension"},"baseLineHeight":{"$value":"20px","$type":"dimension"}},"mode":{"luminance":{"$value":1,"$type":"number"}},"style":{"density":{"$value":1,"$type":"number"},"borderRadius":{"$value":4,"$type":"number"},"strokeWidth":{"$value":1,"$type":"number"}},"space":{"designUnit":{"$value":4,"$type":"number"}}}}' --headerLogo ./logo.png
```

### Route and CSV parameter handling test

```
rm -rf blankappseedtest && npx -y @genesislcap/genx@latest init blankappseedtest --ref sz/default-error-boundary --no-npm -x --routes '[{"name":"Home","icon":"house","tiles":[{"title":"Entity manager","type":"entity-manager","config":{ "modalPosition": "centre", "sizeColumnsToFit": true, "enableSearchBar": true, "resourceName":"ALL_POSITIONS","title":"My Positions","updateEvent":"EVENT_COUNTERPARTY_MODIFY","deleteEvent":"EVENT_COUNTERPARTY_DELETE","createEvent":"EVENT_COUNTERPARTY_INSERT", "createFormUiSchema": {"type":"VerticalLayout","elements":[{"type":"Control","label":"Inline create schema - main contact","scope":"#/properties/MAIN_CONTACT"},{"type":"Control","label":"Issuer Name - Local Schema","scope":"#/properties/ISSUER_NAME","options":{"readonly":true}},{"type":"Control","label":"Price","scope":"#/properties/PRICE"},{"type":"Control","scope":"#/properties/COUNTERPARTY","options":{"allOptionsResourceName":"ALL_COUNTERPARTYS","valueField":"COUNTERPARTY_ID","labelField":"COUNTERPARTY_ID"}},{"type":"Control","label":"Password","scope":"#/properties/PASSWORD","options":{"isPassword":true}},{"type":"Control","label":"Password","scope":"#/properties/PASSWORD","options":{"textarea":true}}]}, "updateFormUiSchema": {"type":"VerticalLayout","elements":[{"type":"Control","label":"Inline update schema - main contact","scope":"#/properties/MAIN_CONTACT"},{"type":"Control","label":"Issuer Name - Local Schema","scope":"#/properties/ISSUER_NAME","options":{"readonly":true}},{"type":"Control","label":"Price","scope":"#/properties/PRICE"},{"type":"Control","scope":"#/properties/COUNTERPARTY","options":{"allOptionsResourceName":"ALL_COUNTERPARTYS","valueField":"COUNTERPARTY_ID","labelField":"COUNTERPARTY_ID"}},{"type":"Control","label":"Password","scope":"#/properties/PASSWORD","options":{"isPassword":true}},{"type":"Control","label":"Password","scope":"#/properties/PASSWORD","options":{"textarea":true}}]}, "columns": [{"field":"INSTRUMENT_NAME","headerName":"Instrument Name"},{"field":"VALUE","headerName":"Inline coldef - VALUE"},{"field":"QUANTITY","headerName":"Quantity"},{"field":"PNL","headerName":"PNL"}] }},{"title":"Grid","type":"grid-pro","config":{"resourceName":"ALL_TRADES", "gridOptions": {"columns":[{"field":"INSTRUMENT_NAME","headerName":"Instrument Name"},{"field":"VALUE","headerName":"Inline coldef - VALUE"},{"field":"QUANTITY","headerName":"Quantity"},{"field":"PNL","headerName":"PNL"}]} }},{"title":"Form","type":"smart-form","config":{"resourceName":"EVENT_COUNTERPARTY_INSERT", "uischema": {"type":"VerticalLayout","elements":[{"type":"Control","label":"Inline form schema - main contact","scope":"#/properties/MAIN_CONTACT"},{"type":"Control","label":"Issuer Name - Local Schema","scope":"#/properties/ISSUER_NAME","options":{"readonly":true}},{"type":"Control","label":"Price","scope":"#/properties/PRICE"},{"type":"Control","scope":"#/properties/COUNTERPARTY","options":{"allOptionsResourceName":"ALL_COUNTERPARTYS","valueField":"COUNTERPARTY_ID","labelField":"COUNTERPARTY_ID"}},{"type":"Control","label":"Password","scope":"#/properties/PASSWORD","options":{"isPassword":true}},{"type":"Control","label":"Password","scope":"#/properties/PASSWORD","options":{"textarea":true}}]} }}]}, {"name":"Realtime Dashboard","icon":"chart-line","tiles":[{"title":"Entity manager tile","type":"entity-manager","config":{"resourceName":"ALL_COUNTERPARTYS","title":"Counterparty Management","updateEvent":"EVENT_COUNTERPARTY_MODIFY","deleteEvent":"EVENT_COUNTERPARTY_DELETE","createEvent":"EVENT_COUNTERPARTY_INSERT"}},{"title":"Form tile","type":"smart-form","config":{"resourceName":"EVENT_COUNTERPARTY_INSERT"}}]},{"name":"Analytics","icon":"chart-pie","tiles":[{"title":"Grid Tile","type":"grid-pro","config":{"resourceName":"ALL_POSITIONS"}},{"title":"Charts Tile 1","type":"chart","config":{"type":"line","resourceName":"ALL_POSITIONS","xField":"INSTRUMENT_NAME","yField":"VALUE"}},{"title":"Charts Tile 2","type":"chart","config":{"type":"pie","resourceName":"ALL_POSITIONS","xField":"INSTRUMENT_NAME","yField":"VALUE"}},{"title":"Charts Tile 3","type":"chart","config":{"type":"column","resourceName":"ALL_POSITIONS","xField":"INSTRUMENT_ID","yField":"VALUE"}}]}]' --csv '[{"name": "trade", "fields": ["a", "B"]}, {"name": "position", "fields": ["id", "TYPE"]} ]' --no-shell && cd blankappseedtest/client && npm run bootstrap && npm run dev
```


<img width="1450" height="889" alt="Screenshot 2026-05-04 at 12 46 29" src="https://github.com/user-attachments/assets/c2f8bee0-c011-4632-9207-77aca5259c74" />

<img width="1450" height="889" alt="Screenshot 2026-05-04 at 12 46 53" src="https://github.com/user-attachments/assets/26b01595-a4be-42ca-86f9-ab5dd0658614" />

✅ &nbsp; **Checklist**



<!--- Review the list and put an x in the boxes that apply. -->


- [x] I have tested my changes.
- [ ] I have added tests for my changes.
- [x] I have updated the project documentation to reflect my changes.