### PR TITLE
fix: small tweaks for react setup GENC-0

### DIFF
--- a/client-tmp/react/src/components/routes/AppRoutes.tsx
+++ b/client-tmp/react/src/components/routes/AppRoutes.tsx
@@ -14,9 +14,13 @@ const AppRoutes = () => {
   return (
     <Routes>
       <Route path="/login" element={<AuthPage />} />
+      {{#if routes.[0]}}
       <Route path="/" element={<Navigate to="/{{kebabCase routes.[0].name}}" replace />} />
+      {{/if}}
       <Route element={<DefaultLayout />}>
+        {{#if routes.[0]}}
         <Route path="/" element={<{{pascalCase routes.[0].name}} />} />
+        {{/if}}
         {routes.map(route => (<Route
             key={route.path}
             path={route.path}

--- a/client-tmp/react/tsconfig.app.json
+++ b/client-tmp/react/tsconfig.app.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src" , "src/**/*.d.ts"],
+  "include": ["src/**/*", "src/**/*.d.ts"],
 }

--- a/client-tmp/react/tsconfig.json
+++ b/client-tmp/react/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": false,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
@@ -27,8 +25,8 @@
     "emitDecoratorMetadata": true
   },
   "include": [
-    "src" ,
-    "src/**/*.d.ts", 
+    "src/**/*",
+    "src/**/*.d.ts",
     "src/pbc/**/*.ts",
   ],
 }


### PR DESCRIPTION
A number of small tweaks to reduce flakiness when running the app, especially during the UI preview flow which dynamically swaps files in and out of a running application.

1. Remove `composite: true` and `tsBuildInfoFile` from the tsconfig. `composite` enforces a strict "every file must be in the resolved include list" check that breaks when files appear at runtime via the preview's file-swap flow. The trade-off is the app can no longer be referenced from another TS project via `tsc -b` — fine since Genesis apps are leaf nodes.
2. Make the `src` include glob explicit (`src/**/*`) — removes a subtle directory-shorthand ambiguity.
3. Add Handlebars `{{#if}}` guards so `AppRoutes.tsx` generates valid JSX when tiles and routes aren't yet defined (previously emitted `<Route path="/" element={< />} />` and broke the parse).