### PR TITLE
fix: more react template guards for empty routes/tiles GENC-0

### DIFF
--- a/.genx/templates/react/route.hbs
+++ b/.genx/templates/react/route.hbs
@@ -1,3 +1,4 @@
+{{#if route.tiles}}
 import React, { useRef } from 'react';
 import { Layout, Model, TabNode } from 'flexlayout-react';
 import { getFlexLayoutStorageKey } from '../../utils/layout';
@@ -5,8 +6,10 @@ import { TileErrorBoundary } from '../../components/error-boundary/ErrorBoundary
 {{#each route.tiles}}
 import { {{pascalCase this.componentName}} } from './{{pascalCase this.title}}{{pascalCase this.componentType}}';
 {{/each}}
+{{/if}}
 import './{{pascalCase route.name}}.css';
 
+{{#if route.tiles}}
 const STORAGE_KEY = getFlexLayoutStorageKey('{{route.layoutKey}}');
 
 {{> (lookup ./route 'layoutType') }}
@@ -26,8 +29,10 @@ function loadModel(): Model {
   }
   return Model.fromJson(defaultLayout);
 }
+{{/if}}
 
 const {{pascalCase route.name}} = () => {
+  {{#if route.tiles}}
   const modelRef = useRef<Model>(loadModel());
 
   const factory = (node: TabNode) => {
@@ -47,6 +52,7 @@ const {{pascalCase route.name}} = () => {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(model.toJson()));
     }
   };
+  {{/if}}
 
   return (
     <section className="{{kebabCase route.name}}-page">

--- a/client-tmp/react/src/components/routes/AppRoutes.tsx
+++ b/client-tmp/react/src/components/routes/AppRoutes.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route{{#if routes.[0]}}, Navigate{{/if}} } from 'react-router-dom';
 import AuthPage from '../../pages/AuthPage/AuthPage';
 {{#if routes.[0]}}
 import {{pascalCase routes.[0].name}} from '../../pages/{{pascalCase routes.[0].name}}/{{pascalCase routes.[0].name}}';


### PR DESCRIPTION
Follow-up to #578 — two more spots where the react templates emit unused identifiers when the upstream config is empty, which trips `noUnusedLocals`.

1. `AppRoutes.tsx`: `Navigate` is only used inside the `{{#if routes.[0]}}` guard added in #578, so when there are no routes the import becomes unused. Pull the named import into the same conditional.
2. `route.hbs`: when a route has no tiles, the `{{else}}` branch of the JSX renders a plain "Welcome to X" message, but the file still emits all the FlexLayout machinery (`Layout/Model/TabNode` imports, `STORAGE_KEY`, `componentMap`, `loadModel`, `modelRef`, `factory`, `onModelChange`). Wrap all the tiles-only code in `{{#if route.tiles}}` guards. The `.css` import and the component shell stay outside the guard.