### PR TITLE
feat: report error boundary failures to genesis-telemetry GENC-1272

### DIFF
--- a/client-tmp/react/src/components/error-boundary/ErrorBoundary.tsx
+++ b/client-tmp/react/src/components/error-boundary/ErrorBoundary.tsx
@@ -152,6 +152,11 @@ class BaseErrorBoundary extends React.Component<BaseErrorBoundaryProps, BaseErro
       error: normalized,
       componentStack: errorInfo.componentStack,
     });
+
+    // Expose to genesis-telemetry.js so the UI Builder agent can read it via get_preview_diagnostics
+    const reports: unknown[] = ((window as any).__GENESIS_ERROR_BOUNDARY_REPORTS__ ??= []);
+    reports.push({ message: normalized.message, stack: normalized.stack ?? null, componentStack: errorInfo.componentStack ?? null, ts: Date.now() });
+    if (reports.length > 20) reports.shift();
   }
 
   private readonly handleRetry = (): void => {


### PR DESCRIPTION
## Summary

Companion to genesislcap/genesis-create#1449.

When a `TileErrorBoundary` (or `AppErrorBoundary`) catches a React render crash, `componentDidCatch` now pushes the error details into `window.__GENESIS_ERROR_BOUNDARY_REPORTS__`. The `genesis-telemetry.js` script injected by genesis-create reads this array and includes it in the diagnostic snapshot sent back to the UI Builder agent via `postMessage`.

Without this change the `reactErrorBoundaryReports` field in `get_preview_diagnostics` is always empty — React boundary crashes are silently swallowed by the error boundary and never reach `window.onerror`.

## Changes

`client-tmp/react/src/components/error-boundary/ErrorBoundary.tsx` — 5 lines added to `componentDidCatch`:

```ts
const reports: unknown[] = ((window as any).__GENESIS_ERROR_BOUNDARY_REPORTS__ ??= []);
reports.push({ message: normalized.message, stack: normalized.stack ?? null, componentStack: errorInfo.componentStack ?? null, ts: Date.now() });
if (reports.length > 20) reports.shift();
```

The array is capped at 20 entries (oldest dropped first). No change to the visible error boundary UI or retry behaviour.

## Test plan

- [ ] Trigger a React render crash inside a tile — `window.__GENESIS_ERROR_BOUNDARY_REPORTS__` in the iframe console contains the error entry
- [ ] `get_preview_diagnostics` tool in genesis-create returns the entry under `reactErrorBoundaryReports`
- [ ] Normal (non-crashing) tiles are unaffected