### PR TITLE
fix: disable flexlayout render-on-demand to prevent duplicate tile mounts GENC-0

### DIFF
--- a/.genx/templates/react/gridLayout.hbs
+++ b/.genx/templates/react/gridLayout.hbs
@@ -1,5 +1,5 @@
 const defaultLayout = {
-  global: { tabEnableClose: false },
+  global: { tabEnableClose: false, tabEnableRenderOnDemand: false },
   layout: {
     type: 'row',
     children: [

--- a/.genx/templates/react/horizontalLayout.hbs
+++ b/.genx/templates/react/horizontalLayout.hbs
@@ -1,5 +1,5 @@
 const defaultLayout = {
-  global: { tabEnableClose: false },
+  global: { tabEnableClose: false, tabEnableRenderOnDemand: false },
   layout: {
     type: 'row',
     children: [

--- a/.genx/templates/react/tabsLayout.hbs
+++ b/.genx/templates/react/tabsLayout.hbs
@@ -1,5 +1,5 @@
 const defaultLayout = {
-  global: { tabEnableClose: false },
+  global: { tabEnableClose: false, tabEnableRenderOnDemand: false },
   layout: {
     type: 'row',
     children: [


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**

[GENC-0](https://genesisglobal.atlassian.net/browse/GENC-0)

🤔 &nbsp; **What does this PR do?**

- Adds `tabEnableRenderOnDemand: false` to the `global` config of the generated React flexLayout `defaultLayout` (tabs, horizontal and grid layout templates).
- Fixes duplicated grid rows seen on generated **tabbed** pages: with flexLayout's default lazy render-on-demand, a tile only mounts when its tab is first shown. Under `React.StrictMode` (dev), that deferred mount runs twice and the first datasource load isn't reset before the second, so auto-setup (REQUEST_SERVER / REQ-REP) grids render every row twice.
- Setting the flag makes flexLayout mount all tab contents eagerly (the same path the horizontal layout already uses, which never exhibited the bug); only the selected tab is still *displayed*.
- For `horizontalLayout`/`gridLayout` each tile is alone in its tabset, so the flag is a no-op for the default rendered state — included for consistency and to guard against the same bug if a user drags tabs together into one tabset at runtime.

🚀 &nbsp; **Where should the reviewer start?**

- `.genx/templates/react/tabsLayout.hbs` — the template that actually reproduces the duplication.
- `.genx/templates/react/horizontalLayout.hbs` and `.genx/templates/react/gridLayout.hbs` — same one-line `global` change for consistency.

📑 &nbsp; **How should this be tested?**

Generate a React app with a multi-tile route using the tabs layout and confirm a REQ-REP / auto-setup grid (e.g. an entity manager backed by a `*_VIEW_QUERY` resource) shows each record once, with StrictMode enabled, on a tabbed page.

```
rm -rf blankappseedtest && npx -y @genesislcap/genx@latest init blankappseedtest -x --ref sz/GENC-0-flexlayout-render-on-demand --no-npm
```

Then in the generated app, open a tabbed page and verify no duplicate rows appear (previously rows doubled, e.g. 12 instead of 6).

✅ &nbsp; **Checklist**

- [x] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.