### PR TITLE
build: v9 toolchain — Gradle wrapper 8.10.2→9.6.0 + Kotlin 2.3.0→2.4.0 (GSF-0)

### DIFF
--- a/bdd-tests/build.gradle.kts
+++ b/bdd-tests/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
-    kotlin("jvm") version "2.3.0"
+    kotlin("jvm") version "2.4.0"
     java
     id("global.genesis.bdd_automation")
 }
@@ -34,7 +34,7 @@ kotlin {
     compilerOptions {
         freeCompilerArgs.addAll("-Xjsr305=strict", "-Xjvm-default=all", "-Xlambdas=indy")
         jvmTarget.set(JvmTarget.JVM_17)
-        apiVersion.set(KotlinVersion.KOTLIN_2_3)
+        apiVersion.set(KotlinVersion.KOTLIN_2_4)
     }
 }
 

--- a/bdd-tests/gradle/wrapper/gradle-wrapper.properties
+++ b/bdd-tests/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -56,7 +56,7 @@ allprojects {
             freeCompilerArgs.addAll("-Xjsr305=strict")
             jvmDefault.set(JvmDefaultMode.NO_COMPATIBILITY)
             jvmTarget.set(JvmTarget.JVM_17)
-            apiVersion.set(KotlinVersion.KOTLIN_2_3)
+            apiVersion.set(KotlinVersion.KOTLIN_2_4)
         }
     }
     tasks.withType<Jar> {

--- a/server/gradle/wrapper/gradle-wrapper.properties
+++ b/server/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## What
Align the seed's JVM toolchain with the genesis **v9** stack:
- **Gradle wrapper 8.10.2 → 9.6.0** (all three: root, `server/`, `bdd-tests/`)
- **Kotlin 2.3.0 → 2.4.0** — `apiVersion` in `server/build.gradle.kts` + `bdd-tests/build.gradle.kts`, and the explicit `kotlin("jvm")` plugin pin in `bdd-tests`. (The `server` module's KGP is unversioned and resolves from genesis `8.16.0-SNAPSHOT`, which is 2.4.0.)

## Why
The genesis `8.16.0-SNAPSHOT` (v9) plugins are compiled against **Gradle 9.6.0 / Kotlin 2.4.0** (genesis-server #5891). A seed app generated against that GSF (`genx init … -s blank-app-seed --ref release-v9`) but built on the seed's pinned **Gradle 8.10.2** fails configuring `:server:…-app`:

```
> Failed to notify project evaluation listener.
   > 'org.gradle.api.Task org.gradle.api.tasks.TaskContainer.create(java.lang.String, org.gradle.api.Action)'
```

(`GenesisExecPlugin` emits Gradle-9 `TaskContainer.create(String, Action)` bytecode, absent on Gradle 8.10.2.) Bumping the wrapper to 9.6.0 + Kotlin to 2.4.0 restores compatibility. The seed's own build is minimal (no ktlint/sonarqube tail).

## Follow-up
A companion change (#592) bumps `.genx/versions.json` **GSF + Auth → 8.16.0-SNAPSHOT** — required so generated apps also resolve the v9 (Gradle-9) plugins rather than the pre-v9 release `8.15.x` (whose `DistributionPlugin` still calls the Gradle-9-removed `setFileMode`).

## Scope / lockstep
Gradle 9.6.0 + Kotlin 2.4.0 (and #592's GSF 8.16.0-SNAPSHOT) move together; valid on **release-v9** only — not for branches on a released Gradle-8 GSF.
