### PR TITLE
feat: enable genesis.codegen.reuseUpstream.strict by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ org.gradle.jvmargs=-Xmx3g -Xss512k -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC 
 kotlin.daemon.jvmargs=-Xmx3g -XX:+UseG1GC -XX:+UseStringDeduplication
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+genesis.codegen.reuseUpstream.strict=true


### PR DESCRIPTION
## What changed

Added `genesis.codegen.reuseUpstream.strict=true` to the root `gradle.properties`.

## Why

This template is used to scaffold new Genesis applications. Setting this property by default ensures all newly created projects opt into strict reuse-upstream mode from the start, without requiring each team to add it manually.

## Reviewer notes

- Change is limited to `gradle.properties` — one line added.
- No code changes; this only affects codegen behaviour in downstream projects scaffolded from this template.