### PR TITLE
build: v9 alignment — Gradle 9.6.1 + javax.inject→jakarta.inject (GSF-0)

### DIFF
--- a/bdd-tests/gradle/wrapper/gradle-wrapper.properties
+++ b/bdd-tests/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,8 @@
 kotlin.code.style=official
-org.gradle.jvmargs=-Xmx3g -Xss512k -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC -XX:+UseStringDeduplication -XX:ReservedCodeCacheSize=512m -Dfile.encoding=UTF-8 -Dlog4j2.shutdownHookEnabled=false
+# -XX:+IgnoreUnrecognizedVMOptions lets the JDK-25 flags that follow be silently ignored on older
+# JDKs (e.g. JDK 17) instead of aborting the build, while taking effect on JDK 24+: clean logs
+# (no sun.misc.Unsafe / native-access warnings) and Compact Object Headers (JEP 519, ~10-22% less heap).
+org.gradle.jvmargs=-Xmx3g -Xss512k -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC -XX:+UseStringDeduplication -XX:ReservedCodeCacheSize=512m -Dfile.encoding=UTF-8 -Dlog4j2.shutdownHookEnabled=false -XX:+IgnoreUnrecognizedVMOptions --sun-misc-unsafe-memory-access=allow --enable-native-access=ALL-UNNAMED -XX:+UseCompactObjectHeaders
 kotlin.daemon.jvmargs=-Xmx3g -XX:+UseG1GC -XX:+UseStringDeduplication
 org.gradle.caching=true
 org.gradle.configuration-cache=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -1,5 +1,8 @@
 bundleGeneratedClasses=true
-org.gradle.jvmargs=-Xmx3g -Xss512k -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC -XX:+UseStringDeduplication -XX:ReservedCodeCacheSize=512m -Dfile.encoding=UTF-8 -Dlog4j2.shutdownHookEnabled=false
+# -XX:+IgnoreUnrecognizedVMOptions lets the JDK-25 flags that follow be silently ignored on older
+# JDKs (e.g. JDK 17) instead of aborting the build, while taking effect on JDK 24+: clean logs
+# (no sun.misc.Unsafe / native-access warnings) and Compact Object Headers (JEP 519, ~10-22% less heap).
+org.gradle.jvmargs=-Xmx3g -Xss512k -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC -XX:+UseStringDeduplication -XX:ReservedCodeCacheSize=512m -Dfile.encoding=UTF-8 -Dlog4j2.shutdownHookEnabled=false -XX:+IgnoreUnrecognizedVMOptions --sun-misc-unsafe-memory-access=allow --enable-native-access=ALL-UNNAMED -XX:+UseCompactObjectHeaders
 kotlin.daemon.jvmargs=-Xmx3g -XX:+UseG1GC -XX:+UseStringDeduplication
 org.gradle.configuration-cache=true
 enableDockerTasks=true

--- a/server/gradle/wrapper/gradle-wrapper.properties
+++ b/server/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/server/{{appName}}-app/src/test/kotlin/global/genesis/EventHandlerTest.kt
+++ b/server/{{appName}}-app/src/test/kotlin/global/genesis/EventHandlerTest.kt
@@ -6,7 +6,7 @@ import global.genesis.db.rx.entity.multi.AsyncEntityDb
 import global.genesis.testsupport.client.eventhandler.EventClientSync
 import global.genesis.testsupport.jupiter.GenesisJunit
 import global.genesis.testsupport.jupiter.ScriptFile
-import javax.inject.Inject
+import jakarta.inject.Inject
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 


### PR DESCRIPTION
## v9 alignment

- **Gradle wrapper 9.6.0 → 9.6.1** (patch).
- **`javax.inject` → `jakarta.inject`** — mechanical import rename mirroring genesis-server #6009. Guice 7.0 (in GSF `8.16.0-SNAPSHOT`) dropped `javax.inject` support, so `@Inject`/`@Singleton`/`@Named`/`Provider` move to `jakarta.inject.*`. `jakarta.inject-api` resolves transitively from the GSF deps — no build-script dependency change. The shaded `org.jetbrains.kotlin.javax.inject` form is left untouched. `javax.annotation` is unaffected (GSF still ships `javax.annotation-api`).

Related: GSF-0