### PR TITLE
chore: switch npm publishing to OIDC trusted publishing (DCD-4786)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment: deploy
+    concurrency:
+      group: publish-${{ github.ref }}
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -18,6 +24,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: https://registry.npmjs.org
 
       - name: Release
         env:
@@ -43,8 +50,5 @@ jobs:
         run: npm pack -dry
 
       - name: Publish
-        uses: JS-DevTools/npm-publish@v3
-        with:
-          token: ${{secrets.NPM_TOKEN}}
-          tag: ${{ steps.dist-tag.outputs.DIST_TAG }}
-
+        if: steps.dist-tag.outputs.DIST_TAG != ''
+        run: npm publish --tag "${{ steps.dist-tag.outputs.DIST_TAG }}"


### PR DESCRIPTION
Description:
## Why

npm now requires access tokens to be rotated every 90 days and can auto-rotate them during supply-chain attacks. To remove manual token rotation and align with current npm security best practices, we are switching to OIDC-based trusted publishing — no long-lived secrets required.

Trusted publishing for this package needs to be configured on npm.com (Provider: GitHub Actions, repo: blank-app-seed, workflow: release.yml, environment: deploy) before merging.

## What changed

**`release.yml`**
- Added `permissions: contents: read / id-token: write` so GitHub can mint an OIDC token for the publish step
- Added `registry-url: https://registry.npmjs.org` to setup-node (required for OIDC token exchange)
- Added `concurrency` group to serialise runs and prevent double-publish races if two merges land close together (`cancel-in-progress: false` so in-flight publishes are never killed)
- Replaced `JS-DevTools/npm-publish@v3` + `NPM_TOKEN` with plain `npm publish`, gated on `DIST_TAG != ''` to replicate the skip-if-no-release behaviour

`GH_USER_TOKEN` is kept — it is still needed for the release script to push tags and commits to GitHub.

## How to verify

1. Merge a commit to `prerelease` → release script runs → if version bumped, publishes with prerelease dist-tag via OIDC
2. Merge to `main` → publishes as `latest` via OIDC
3. Confirm no `NPM_TOKEN` is involved in the publish path

## Follow-up (after first successful OIDC publish)

- npm package Settings → Publishing access → Require 2FA and disallow tokens
- Delete the `NPM_TOKEN` repo secret (confirm `GH_USER_TOKEN` is separate and still needed)