### PR TITLE
fix(react): generate + wire column defs for grid-pro tiles with top-level columns PTC-0

### DIFF
--- a/.genx/templates/react/component/component.hbs
+++ b/.genx/templates/react/component/component.hbs
@@ -3,7 +3,7 @@ import { EntityManagement } from '@genesislcap/foundation-entity-management/reac
 {{/ifEquals}}
 {{#ifEquals tile.type 'grid-pro'}}
 import { RapidGridPro } from '@genesislcap/rapid-grid-pro/react';
-import { GridProGenesisDatasource{{#if tile.config.gridOptions}}, GridProColumn{{/if}} } from '@genesislcap/grid-pro/react';
+import { GridProGenesisDatasource{{#ifAny tile.config.gridOptions tile.config.columns}}, GridProColumn{{/ifAny}} } from '@genesislcap/grid-pro/react';
 import { GridProCaseType } from '@genesislcap/grid-pro';
 {{/ifEquals}}
 {{#ifEquals tile.type 'smart-form'}}

--- a/.genx/templates/react/grid.hbs
+++ b/.genx/templates/react/grid.hbs
@@ -25,7 +25,11 @@ hasUserPermission('{{config.permissions.viewRight}}') ? (
     pollingInterval={datasourceConfig.pollingInterval}
     {{/if}}
   />
-  {{#if config.gridOptions}}
+  {{#if config.columns}}
+  {columnDefs.map((columnDef, index) => (
+    <GridProColumn key={index} definition={columnDef} />
+  ))}
+  {{else if config.gridOptions}}
   {gridOptionsTile?.columnDefs?.map((columnDef, index) => (
     <GridProColumn key={index} definition={columnDef} />
   ))}

--- a/.genx/utils/formatRouteData.js
+++ b/.genx/utils/formatRouteData.js
@@ -60,7 +60,7 @@ const formatRouteData = (framework, route) => {
         ...config,
         index,
         gridOptions: gridOptionsSerializer(gridOptions),
-        useOnlyTemplateCols: !!gridOptions?.columns,
+        useOnlyTemplateCols: !!gridOptions?.columns || !!columns,
         createFormUiSchema: formatJSONValue(createFormUiSchema),
         updateFormUiSchema: formatJSONValue(updateFormUiSchema),
         filterFormUiSchema: formatJSONValue(filterFormUiSchema),

--- a/.genx/utils/generateTile.js
+++ b/.genx/utils/generateTile.js
@@ -171,6 +171,9 @@ const getFilesToWrite = (
       }
       break;
     case 'grid-pro':
+      if (tileData.config?.columns) {
+        filesToWrite.push(componentColumnsFile);
+      }
       if (tileData.config?.gridOptions) {
         filesToWrite.push(componentGridOptionsFile);
       }


### PR DESCRIPTION
📓 &nbsp; **Related JIRA**

[PTC-0](https://genesisglobal.atlassian.net/browse/PTC-0)

🤔 &nbsp; **What does this PR do?**

Fixes a build-breaking bug when a **`grid-pro` tile** is defined with top-level `config.columns`. The React tile template imported and declared the column defs, but the generator never emitted the file and the grid partial never rendered them — so a generated app failed to build with:

```
Cannot find module './<Tile>ColumnDefs'
'columnDefs' is declared but its value is never read.  (TS6133)
```

Root cause was a template↔generator mismatch (only `entity-manager` handled top-level columns):
- `component.hbs` imports `./<Tile>ColumnDefs` and declares `const columnDefs` whenever `config.columns` is set (any tile type)…
- …but `generateTile.js` only emitted the `ColumnDefs` file for `entity-manager`, and `grid.hbs` only rendered columns from `gridOptions.columnDefs` — never the top-level `columnDefs`.

Changes:
- **`generateTile.js`** — emit the `ColumnDefs` file for `grid-pro` when `config.columns` (as `entity-manager` already does).
- **`component.hbs`** — import `GridProColumn` when `columns` **or** `gridOptions`.
- **`grid.hbs`** — render the top-level `columnDefs` as `<GridProColumn>` children (falling back to `gridOptions.columnDefs`), so the const is used and the columns actually apply.
- **`formatRouteData.js`** — set `onlyTemplateColDefs` when explicit `columns` are provided, so they're authoritative.

🚀 &nbsp; **Where should the reviewer start?**

- `.genx/utils/generateTile.js` — the `grid-pro` case in `getFilesToWrite`.
- `.genx/templates/react/grid.hbs` — the column-rendering block.
- `.genx/templates/react/component/component.hbs` — the `GridProColumn` import.
- `.genx/utils/formatRouteData.js` — `useOnlyTemplateCols`.

📑 &nbsp; **How should this be tested?**

Generate an app with a `grid-pro` tile that uses top-level `columns`, then build it:

```
rm -rf tilefixtest && npx -y @genesislcap/genx@latest init tilefixtest -x --ref fix/grid-pro-tile-column-defs --no-npm --framework react --routes '[{"name":"orders","title":"Orders","icon":"list","tiles":[{"type":"grid-pro","title":"Orders Blotter","config":{"resourceName":"ALL_ORDERS","columns":[{"field":"ORDER_ID"},{"field":"QUANTITY"},{"field":"PRICE"}]}}]}]'
cd tilefixtest/client && npm i && npm run build
```

Verified locally: the `OrdersBlotterColumnDefs.ts` file is now generated, `columnDefs` is rendered via `<GridProColumn>`, **`tsc --noEmit` = 0 errors**, and **`npm run build` succeeds**. (Before this fix the same generation failed with the two errors above.)

> Found while testing the react-router-utils template migration (#607); this tile-generator bug is independent of that PR.

✅ &nbsp; **Checklist**

- [x] I have tested my changes.
- [ ] I have added tests for my changes.
I have updated the release instructions for my changes...
  - [ ] ...with deployment instructions.
  - [ ] ...with rollback instructions.
- [ ] I have updated the project documentation to reflect my changes.