### PR TITLE
fix: Bump BDD framework (bddVersion) from 3.5.30 to 3.5.73 GENC-0

### DIFF
--- a/bdd-tests/gradle.properties
+++ b/bdd-tests/gradle.properties
@@ -3,6 +3,6 @@
 org.gradle.configuration-cache=false
 org.gradle.parallel=true
 org.gradle.caching=true
-bddVersion=3.5.30
+bddVersion=3.5.73
 useDevRepo=true
 


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**

[PTC-0](https://genesisglobal.atlassian.net/browse/PTC-0)

🤔 &nbsp; **What does this PR do?**

- Bumps `bdd-tests/gradle.properties` `bddVersion` from **3.5.30** to **3.5.73** — one line, no other changes.
- 3.5.30 predates the current JSON comparison behaviour. On 3.5.30, a column that the verification query returns but the expected-results file does not list is reported as a **comparison failure**; from the newer comparator it is a **warning** (`JSON comparison passed with warning`, `PENDING`/`Extra fields:`) and the scenario stays green.
- That difference is why every generated app currently has to enumerate every returned column — including nullable ones it does not care about, as explicit `null`s — or the run fails on fields like an unset optional foreign key.

**Why 3.5.73 specifically**

- It is the latest version published to `libs-release-client`, which is what generated apps resolve from (`useDevRepo` unset).
- It is also present in `dev-repo`, so this repository's own `useDevRepo=true` builds resolve it too.
- 3.5.74 exists as a git tag in `platform-qa-automation` but was **never published to either repository**, so it is not a usable target.

🚀 &nbsp; **Where should the reviewer start?**

`bdd-tests/gradle.properties` — the only changed file. Worth a look at `bdd-tests/settings.gradle.kts` to confirm nothing else pins the plugin version (it reads `bddVersion` and nothing more).

📑 &nbsp; **How should this be tested?**

Verified against the real artifacts before opening this, using a generated app's `bdd-tests` module (the same layout this seed ships):

1. **Resolution** — set `bddVersion=3.5.73` and run `./gradlew testClasses`. Result: `BUILD SUCCESSFUL`; the plugin and its dependencies resolved from JFrog, and `support/runner/CucumberRunner` compiled against it, so `AbstractGenesisCucumberRunner` is API-compatible.
2. **The behaviour change is present** — `genesis-bdd-testing-3.5.73.jar` contains `pendingExtrasOnlyMessage`, `"JSON comparison passed with warning for "`, `PENDING`/`Extra fields:` and a `ComparisonResultAdapter` mapping to `ComparisonStatus.{PASS,FAIL,EXTRA}`; 3.5.30 has none of these.
3. **Standard seed check** — an init from this branch:

```
rm -rf blankappseedtest && npx -y @genesislcap/genx@latest init blankappseedtest -x --ref bump-bdd-framework-3.5.73 --no-npm
```

What I could **not** verify from here, and would ask for on your side: a full BDD run against a live app, i.e. that every step definition still binds at runtime. Compilation proves the runner's API matches, not that the step registry is unchanged across 44 versions. If a step no longer binds, reverting is a one-line change.

✅ &nbsp; **Checklist**

- [x] I have tested my changes. *(resolution + compilation + comparator-behaviour checks above; full runtime BDD run not performed — see note)*
- [ ] I have added tests for my changes. *(version bump only; no new code paths)*
- [ ] I have updated the project documentation to reflect my changes. *(no documented behaviour changes; the comparison difference is in the framework, not the seed)*
