### PR TITLE
fix: Bump BDD framework (bddVersion) from 3.5.30 to 3.5.73 GENC-0

### DIFF
--- a/bdd-tests/gradle.properties
+++ b/bdd-tests/gradle.properties
@@ -3,5 +3,5 @@
 org.gradle.configuration-cache=false
 org.gradle.parallel=true
 org.gradle.caching=true
-bddVersion=3.5.30
+bddVersion=3.5.73
 


### PR DESCRIPTION
[Review Guidance](https://www.notion.so/genesisglobal/Platform-Code-Review-Process-ace93ba760cc4563b0dfb712e2a88d8a)

📓 &nbsp; **Related JIRA**

[PTC-0](https://genesisglobal.atlassian.net/browse/PTC-0)

🤔 &nbsp; **What does this PR do?**

Same one-line change as #609 (already merged), targeted at `main` this time.

#609 went to `prerelease` because that is the default branch, but released versions appear to be cut from `main` (`v5.19.x`, `v5.20.0`, `v5.21.0` are all reachable from it), so on its own #609 cannot reach a version consumers can install:

| | `bddVersion` |
|---|---|
| `main` / `5.21.0` (`latest`) | 3.5.30 |
| `5.19.2` (what genesis-create pins) | 3.5.30 |
| `prerelease` / `5.17.3-prerelease.2` (has #609) | **3.5.73** |

Pinning the prerelease build is not a way around it: `prerelease` and `main` have diverged in both directions (prerelease ahead by 17 commits, **main ahead by 28**), so consuming a `5.17.3-prerelease.*` build would drop those 28 commits of main work — regardless of how the prerelease line is versioned. Hence this second PR rather than a version bump on the prerelease side.

If `prerelease` is periodically merged forward into `main`, feel free to close this and let that carry it — the only thing that matters is that the bump reaches the branch releases are cut from.

**Why 3.5.73**

- Latest version published to `libs-release-client`, which is what generated apps resolve from (`useDevRepo` unset — note `main`'s copy of this file has no `useDevRepo` line, unlike `prerelease`'s).
- Also present in `dev-repo`.
- 3.5.74 exists as a git tag in `platform-qa-automation` but was never published to either repository, so it is not a usable target.

🚀 &nbsp; **Where should the reviewer start?**

`bdd-tests/gradle.properties` — the only changed file, one line. `bdd-tests/settings.gradle.kts` reads `bddVersion` and nothing else pins the plugin.

📑 &nbsp; **How should this be tested?**

Already validated at runtime for #609, on a Genesis app generated from this seed's `bdd-tests` layout:

- `bddVersion=3.5.73` → `./gradlew testClasses` → `BUILD SUCCESSFUL` (plugin resolves; `support/runner/CucumberRunner` compiles, so `AbstractGenesisCucumberRunner` is API-compatible).
- Full BDD run against a live app: `BDD tests passed`, `tests="6" skipped="0" failures="0" errors="0"` — 6 scenarios (2 ACK + 4 NACK), first attempt, no retries. Step definitions still bind across the version gap and the `@TAG_<EVENT_HANDLER>` filter still selects.
- No `passed with warning` occurrences, so the suite passes on its own merits rather than relying on the newer comparator's leniency about extra fields.

Standard seed check from this branch:

```
rm -rf blankappseedtest && npx -y @genesislcap/genx@latest init blankappseedtest -x --ref bump-bdd-framework-3.5.73-main --no-npm
```

**What the bump fixes:** on 3.5.30, `CompareJSON.compareFields` walks the union of expected and actual field names and reports any field present on only one side, so a column the verification query returns but the expected-results file omits fails the comparison — surfacing as the confusing `Expected: X = null / Actual: X = null`. The newer comparator reports it as `PENDING`/extra and the scenario stays green.

✅ &nbsp; **Checklist**

- [x] I have tested my changes. *(resolution, compilation and a full runtime BDD run — see above)*
- [ ] I have added tests for my changes. *(version bump only; no new code paths)*
- [ ] I have updated the project documentation to reflect my changes. *(no documented seed behaviour changes; the comparison difference is in the framework)*
